### PR TITLE
Relaxing OAuth-ACE profiles

### DIFF
--- a/draft-ietf-ace-oauth-authz.html
+++ b/draft-ietf-ace-oauth-authz.html
@@ -373,93 +373,93 @@
   /*]]>*/
   </style>
 
-  <link href="#rfc.toc" rel="Contents"/>
-<link href="#rfc.section.1" rel="Chapter" title="1 Introduction"/>
-<link href="#rfc.section.2" rel="Chapter" title="2 Terminology"/>
-<link href="#rfc.section.3" rel="Chapter" title="3 Overview"/>
-<link href="#rfc.section.3.1" rel="Chapter" title="3.1 OAuth 2.0"/>
-<link href="#rfc.section.3.2" rel="Chapter" title="3.2 CoAP"/>
-<link href="#rfc.section.4" rel="Chapter" title="4 Protocol Interactions"/>
-<link href="#rfc.section.5" rel="Chapter" title="5 Framework"/>
-<link href="#rfc.section.5.1" rel="Chapter" title="5.1 Discovering Authorization Servers"/>
-<link href="#rfc.section.5.1.1" rel="Chapter" title="5.1.1 Unauthorized Resource Request Message"/>
-<link href="#rfc.section.5.1.2" rel="Chapter" title="5.1.2 AS Information"/>
-<link href="#rfc.section.5.2" rel="Chapter" title="5.2 Authorization Grants"/>
-<link href="#rfc.section.5.3" rel="Chapter" title="5.3 Client Credentials"/>
-<link href="#rfc.section.5.4" rel="Chapter" title="5.4 AS Authentication"/>
-<link href="#rfc.section.5.5" rel="Chapter" title="5.5 The Authorization Endpoint"/>
-<link href="#rfc.section.5.6" rel="Chapter" title="5.6 The Token Endpoint"/>
-<link href="#rfc.section.5.6.1" rel="Chapter" title="5.6.1 Client-to-AS Request"/>
-<link href="#rfc.section.5.6.2" rel="Chapter" title="5.6.2 AS-to-Client Response"/>
-<link href="#rfc.section.5.6.3" rel="Chapter" title="5.6.3 Error Response"/>
-<link href="#rfc.section.5.6.4" rel="Chapter" title="5.6.4 Request and Response Parameters"/>
-<link href="#rfc.section.5.6.4.1" rel="Chapter" title="5.6.4.1 Audience"/>
-<link href="#rfc.section.5.6.4.2" rel="Chapter" title="5.6.4.2 Grant Type"/>
-<link href="#rfc.section.5.6.4.3" rel="Chapter" title="5.6.4.3 Token Type"/>
-<link href="#rfc.section.5.6.4.4" rel="Chapter" title="5.6.4.4 Profile"/>
-<link href="#rfc.section.5.6.4.5" rel="Chapter" title="5.6.4.5 Confirmation"/>
-<link href="#rfc.section.5.6.5" rel="Chapter" title="5.6.5 Mapping parameters to CBOR"/>
-<link href="#rfc.section.5.7" rel="Chapter" title="5.7 The 'Introspect' Endpoint"/>
-<link href="#rfc.section.5.7.1" rel="Chapter" title="5.7.1 RS-to-AS Request"/>
-<link href="#rfc.section.5.7.2" rel="Chapter" title="5.7.2 AS-to-RS Response"/>
-<link href="#rfc.section.5.7.3" rel="Chapter" title="5.7.3 Error Response"/>
-<link href="#rfc.section.5.7.4" rel="Chapter" title="5.7.4 Client Token"/>
-<link href="#rfc.section.5.7.5" rel="Chapter" title="5.7.5 Mapping Introspection parameters to CBOR"/>
-<link href="#rfc.section.5.8" rel="Chapter" title="5.8 The Access Token"/>
-<link href="#rfc.section.5.8.1" rel="Chapter" title="5.8.1 The 'Authorization Information' Endpoint"/>
-<link href="#rfc.section.5.8.2" rel="Chapter" title="5.8.2 Token Expiration"/>
-<link href="#rfc.section.6" rel="Chapter" title="6 Security Considerations"/>
-<link href="#rfc.section.6.1" rel="Chapter" title="6.1 Unprotected AS Information"/>
-<link href="#rfc.section.6.2" rel="Chapter" title="6.2 Use of Nonces for Replay Protection"/>
-<link href="#rfc.section.6.3" rel="Chapter" title="6.3 Combining profiles"/>
-<link href="#rfc.section.6.4" rel="Chapter" title="6.4 Error responses"/>
-<link href="#rfc.section.7" rel="Chapter" title="7 Privacy Considerations"/>
-<link href="#rfc.section.8" rel="Chapter" title="8 IANA Considerations"/>
-<link href="#rfc.section.8.1" rel="Chapter" title="8.1 Authorization Server Information"/>
-<link href="#rfc.section.8.2" rel="Chapter" title="8.2 OAuth Error Code CBOR Mappings Registry"/>
-<link href="#rfc.section.8.3" rel="Chapter" title="8.3 OAuth Grant Type CBOR Mappings"/>
-<link href="#rfc.section.8.4" rel="Chapter" title="8.4 OAuth Access Token Types"/>
-<link href="#rfc.section.8.5" rel="Chapter" title="8.5 OAuth Token Type CBOR Mappings"/>
-<link href="#rfc.section.8.5.1" rel="Chapter" title="8.5.1 Initial Registry Contents"/>
-<link href="#rfc.section.8.6" rel="Chapter" title="8.6 ACE OAuth Profile Registry"/>
-<link href="#rfc.section.8.7" rel="Chapter" title="8.7 OAuth Parameter Registration"/>
-<link href="#rfc.section.8.8" rel="Chapter" title="8.8 OAuth CBOR Parameter Mappings Registry"/>
-<link href="#rfc.section.8.9" rel="Chapter" title="8.9 OAuth Introspection Response Parameter Registration"/>
-<link href="#rfc.section.8.10" rel="Chapter" title="8.10 Introspection Endpoint CBOR Mappings Registry"/>
-<link href="#rfc.section.8.11" rel="Chapter" title="8.11 JSON Web Token Claims"/>
-<link href="#rfc.section.8.12" rel="Chapter" title="8.12 CBOR Web Token Claims"/>
-<link href="#rfc.section.8.13" rel="Chapter" title="8.13 CoAP Option Number Registration"/>
-<link href="#rfc.section.9" rel="Chapter" title="9 Acknowledgments"/>
-<link href="#rfc.references" rel="Chapter" title="10 References"/>
-<link href="#rfc.references.1" rel="Chapter" title="10.1 Normative References"/>
-<link href="#rfc.references.2" rel="Chapter" title="10.2 Informative References"/>
-<link href="#rfc.appendix.A" rel="Chapter" title="A Design Justification"/>
-<link href="#rfc.appendix.B" rel="Chapter" title="B Roles and Responsibilities"/>
-<link href="#rfc.appendix.C" rel="Chapter" title="C Requirements on Profiles"/>
-<link href="#rfc.appendix.D" rel="Chapter" title="D Assumptions on AS knowledge about C and RS"/>
-<link href="#rfc.appendix.E" rel="Chapter" title="E Deployment Examples"/>
-<link href="#rfc.appendix.E.1" rel="Chapter" title="E.1 Local Token Validation"/>
-<link href="#rfc.appendix.E.2" rel="Chapter" title="E.2 Introspection Aided Token Validation"/>
-<link href="#rfc.appendix.F" rel="Chapter" title="F Document Updates"/>
-<link href="#rfc.appendix.F.1" rel="Chapter" title="F.1 Version -09 to -10"/>
-<link href="#rfc.appendix.F.2" rel="Chapter" title="F.2 Version -08 to -09"/>
-<link href="#rfc.appendix.F.3" rel="Chapter" title="F.3 Version -07 to -08"/>
-<link href="#rfc.appendix.F.4" rel="Chapter" title="F.4 Version -06 to -07"/>
-<link href="#rfc.appendix.F.5" rel="Chapter" title="F.5 Version -05 to -06"/>
-<link href="#rfc.appendix.F.6" rel="Chapter" title="F.6 Version -04 to -05"/>
-<link href="#rfc.appendix.F.7" rel="Chapter" title="F.7 Version -03 to -04"/>
-<link href="#rfc.appendix.F.8" rel="Chapter" title="F.8 Version -02 to -03"/>
-<link href="#rfc.appendix.F.9" rel="Chapter" title="F.9 Version -01 to -02"/>
-<link href="#rfc.appendix.F.10" rel="Chapter" title="F.10 Version -00 to -01"/>
-<link href="#rfc.authors" rel="Chapter"/>
+  <link href="#rfc.toc" rel="Contents">
+<link href="#rfc.section.1" rel="Chapter" title="1 Introduction">
+<link href="#rfc.section.2" rel="Chapter" title="2 Terminology">
+<link href="#rfc.section.3" rel="Chapter" title="3 Overview">
+<link href="#rfc.section.3.1" rel="Chapter" title="3.1 OAuth 2.0">
+<link href="#rfc.section.3.2" rel="Chapter" title="3.2 CoAP">
+<link href="#rfc.section.4" rel="Chapter" title="4 Protocol Interactions">
+<link href="#rfc.section.5" rel="Chapter" title="5 Framework">
+<link href="#rfc.section.5.1" rel="Chapter" title="5.1 Discovering Authorization Servers">
+<link href="#rfc.section.5.1.1" rel="Chapter" title="5.1.1 Unauthorized Resource Request Message">
+<link href="#rfc.section.5.1.2" rel="Chapter" title="5.1.2 AS Information">
+<link href="#rfc.section.5.2" rel="Chapter" title="5.2 Authorization Grants">
+<link href="#rfc.section.5.3" rel="Chapter" title="5.3 Client Credentials">
+<link href="#rfc.section.5.4" rel="Chapter" title="5.4 AS Authentication">
+<link href="#rfc.section.5.5" rel="Chapter" title="5.5 The Authorization Endpoint">
+<link href="#rfc.section.5.6" rel="Chapter" title="5.6 The Token Endpoint">
+<link href="#rfc.section.5.6.1" rel="Chapter" title="5.6.1 Client-to-AS Request">
+<link href="#rfc.section.5.6.2" rel="Chapter" title="5.6.2 AS-to-Client Response">
+<link href="#rfc.section.5.6.3" rel="Chapter" title="5.6.3 Error Response">
+<link href="#rfc.section.5.6.4" rel="Chapter" title="5.6.4 Request and Response Parameters">
+<link href="#rfc.section.5.6.4.1" rel="Chapter" title="5.6.4.1 Audience">
+<link href="#rfc.section.5.6.4.2" rel="Chapter" title="5.6.4.2 Grant Type">
+<link href="#rfc.section.5.6.4.3" rel="Chapter" title="5.6.4.3 Token Type">
+<link href="#rfc.section.5.6.4.4" rel="Chapter" title="5.6.4.4 Profile">
+<link href="#rfc.section.5.6.4.5" rel="Chapter" title="5.6.4.5 Confirmation">
+<link href="#rfc.section.5.6.5" rel="Chapter" title="5.6.5 Mapping Parameters to CBOR">
+<link href="#rfc.section.5.7" rel="Chapter" title="5.7 The 'Introspect' Endpoint">
+<link href="#rfc.section.5.7.1" rel="Chapter" title="5.7.1 RS-to-AS Request">
+<link href="#rfc.section.5.7.2" rel="Chapter" title="5.7.2 AS-to-RS Response">
+<link href="#rfc.section.5.7.3" rel="Chapter" title="5.7.3 Error Response">
+<link href="#rfc.section.5.7.4" rel="Chapter" title="5.7.4 Client Token">
+<link href="#rfc.section.5.7.5" rel="Chapter" title="5.7.5 Mapping Introspection parameters to CBOR">
+<link href="#rfc.section.5.8" rel="Chapter" title="5.8 The Access Token">
+<link href="#rfc.section.5.8.1" rel="Chapter" title="5.8.1 The 'Authorization Information' Endpoint">
+<link href="#rfc.section.5.8.2" rel="Chapter" title="5.8.2 Token Expiration">
+<link href="#rfc.section.6" rel="Chapter" title="6 Security Considerations">
+<link href="#rfc.section.6.1" rel="Chapter" title="6.1 Unprotected AS Information">
+<link href="#rfc.section.6.2" rel="Chapter" title="6.2 Use of Nonces for Replay Protection">
+<link href="#rfc.section.6.3" rel="Chapter" title="6.3 Combining profiles">
+<link href="#rfc.section.6.4" rel="Chapter" title="6.4 Error responses">
+<link href="#rfc.section.7" rel="Chapter" title="7 Privacy Considerations">
+<link href="#rfc.section.8" rel="Chapter" title="8 IANA Considerations">
+<link href="#rfc.section.8.1" rel="Chapter" title="8.1 Authorization Server Information">
+<link href="#rfc.section.8.2" rel="Chapter" title="8.2 OAuth Error Code CBOR Mappings Registry">
+<link href="#rfc.section.8.3" rel="Chapter" title="8.3 OAuth Grant Type CBOR Mappings">
+<link href="#rfc.section.8.4" rel="Chapter" title="8.4 OAuth Access Token Types">
+<link href="#rfc.section.8.5" rel="Chapter" title="8.5 OAuth Token Type CBOR Mappings">
+<link href="#rfc.section.8.5.1" rel="Chapter" title="8.5.1 Initial Registry Contents">
+<link href="#rfc.section.8.6" rel="Chapter" title="8.6 ACE OAuth Profile Registry">
+<link href="#rfc.section.8.7" rel="Chapter" title="8.7 OAuth Parameter Registration">
+<link href="#rfc.section.8.8" rel="Chapter" title="8.8 OAuth CBOR Parameter Mappings Registry">
+<link href="#rfc.section.8.9" rel="Chapter" title="8.9 OAuth Introspection Response Parameter Registration">
+<link href="#rfc.section.8.10" rel="Chapter" title="8.10 Introspection Endpoint CBOR Mappings Registry">
+<link href="#rfc.section.8.11" rel="Chapter" title="8.11 JSON Web Token Claims">
+<link href="#rfc.section.8.12" rel="Chapter" title="8.12 CBOR Web Token Claims">
+<link href="#rfc.section.8.13" rel="Chapter" title="8.13 CoAP Option Number Registration">
+<link href="#rfc.section.9" rel="Chapter" title="9 Acknowledgments">
+<link href="#rfc.references" rel="Chapter" title="10 References">
+<link href="#rfc.references.1" rel="Chapter" title="10.1 Normative References">
+<link href="#rfc.references.2" rel="Chapter" title="10.2 Informative References">
+<link href="#rfc.appendix.A" rel="Chapter" title="A Design Justification">
+<link href="#rfc.appendix.B" rel="Chapter" title="B Roles and Responsibilities">
+<link href="#rfc.appendix.C" rel="Chapter" title="C Requirements on Profiles">
+<link href="#rfc.appendix.D" rel="Chapter" title="D Assumptions on AS knowledge about C and RS">
+<link href="#rfc.appendix.E" rel="Chapter" title="E Deployment Examples">
+<link href="#rfc.appendix.E.1" rel="Chapter" title="E.1 Local Token Validation">
+<link href="#rfc.appendix.E.2" rel="Chapter" title="E.2 Introspection Aided Token Validation">
+<link href="#rfc.appendix.F" rel="Chapter" title="F Document Updates">
+<link href="#rfc.appendix.F.1" rel="Chapter" title="F.1 Version -09 to -10">
+<link href="#rfc.appendix.F.2" rel="Chapter" title="F.2 Version -08 to -09">
+<link href="#rfc.appendix.F.3" rel="Chapter" title="F.3 Version -07 to -08">
+<link href="#rfc.appendix.F.4" rel="Chapter" title="F.4 Version -06 to -07">
+<link href="#rfc.appendix.F.5" rel="Chapter" title="F.5 Version -05 to -06">
+<link href="#rfc.appendix.F.6" rel="Chapter" title="F.6 Version -04 to -05">
+<link href="#rfc.appendix.F.7" rel="Chapter" title="F.7 Version -03 to -04">
+<link href="#rfc.appendix.F.8" rel="Chapter" title="F.8 Version -02 to -03">
+<link href="#rfc.appendix.F.9" rel="Chapter" title="F.9 Version -01 to -02">
+<link href="#rfc.appendix.F.10" rel="Chapter" title="F.10 Version -00 to -01">
+<link href="#rfc.authors" rel="Chapter">
 
 
-  <meta name="generator" content="xml2rfc version 2.5.1 - http://tools.ietf.org/tools/xml2rfc" />
+  <meta name="generator" content="xml2rfc version 2.8.2 - https://tools.ietf.org/tools/xml2rfc" />
   <link rel="schema.dct" href="http://purl.org/dc/terms/" />
 
   <meta name="dct.creator" content="Seitz, L., Selander, G., Wahlstroem, E., Erdtman, S., and H. Tschofenig" />
   <meta name="dct.identifier" content="urn:ietf:id:draft-ietf-ace-oauth-authz-10" />
-  <meta name="dct.issued" scheme="ISO8601" content="2017-11-23" />
+  <meta name="dct.issued" scheme="ISO8601" content="2017-12-18" />
   <meta name="dct.abstract" content="This specification defines a framework for authentication and authorization in Internet of Things (IoT) environments. The framework is based on a set of building blocks including OAuth 2.0 and CoAP, thus making a well-known and widely used authorization solution suitable for IoT devices.  Existing specifications are used where possible, but where the constraints of IoT devices require it, extensions are added and profiles are defined.  " />
   <meta name="description" content="This specification defines a framework for authentication and authorization in Internet of Things (IoT) environments. The framework is based on a set of building blocks including OAuth 2.0 and CoAP, thus making a well-known and widely used authorization solution suitable for IoT devices.  Existing specifications are used where possible, but where the constraints of IoT devices require it, extensions are added and profiles are defined.  " />
 
@@ -471,48 +471,48 @@
     <tbody>
     
     	<tr>
-  <td class="left">ACE Working Group</td>
-  <td class="right">L. Seitz</td>
+<td class="left">ACE Working Group</td>
+<td class="right">L. Seitz</td>
 </tr>
 <tr>
-  <td class="left">Internet-Draft</td>
-  <td class="right">RISE SICS</td>
+<td class="left">Internet-Draft</td>
+<td class="right">RISE SICS</td>
 </tr>
 <tr>
-  <td class="left">Intended status: Standards Track</td>
-  <td class="right">G. Selander</td>
+<td class="left">Intended status: Standards Track</td>
+<td class="right">G. Selander</td>
 </tr>
 <tr>
-  <td class="left">Expires: May 27, 2018</td>
-  <td class="right">Ericsson</td>
+<td class="left">Expires: June 21, 2018</td>
+<td class="right">Ericsson</td>
 </tr>
 <tr>
-  <td class="left"></td>
-  <td class="right">E. Wahlstroem</td>
+<td class="left"></td>
+<td class="right">E. Wahlstroem</td>
 </tr>
 <tr>
-  <td class="left"></td>
-  <td class="right"></td>
+<td class="left"></td>
+<td class="right"></td>
 </tr>
 <tr>
-  <td class="left"></td>
-  <td class="right">S. Erdtman</td>
+<td class="left"></td>
+<td class="right">S. Erdtman</td>
 </tr>
 <tr>
-  <td class="left"></td>
-  <td class="right">Spotify AB</td>
+<td class="left"></td>
+<td class="right">Spotify AB</td>
 </tr>
 <tr>
-  <td class="left"></td>
-  <td class="right">H. Tschofenig</td>
+<td class="left"></td>
+<td class="right">H. Tschofenig</td>
 </tr>
 <tr>
-  <td class="left"></td>
-  <td class="right">ARM Ltd.</td>
+<td class="left"></td>
+<td class="right">ARM Ltd.</td>
 </tr>
 <tr>
-  <td class="left"></td>
-  <td class="right">November 23, 2017</td>
+<td class="left"></td>
+<td class="right">December 18, 2017</td>
 </tr>
 
     	
@@ -522,172 +522,271 @@
   <p class="title">Authentication and Authorization for Constrained Environments (ACE)<br />
   <span class="filename">draft-ietf-ace-oauth-authz-10</span></p>
   
-  <h1 id="rfc.abstract">
-  <a href="#rfc.abstract">Abstract</a>
-</h1>
+  <h1 id="rfc.abstract"><a href="#rfc.abstract">Abstract</a></h1>
 <p>This specification defines a framework for authentication and authorization in Internet of Things (IoT) environments. The framework is based on a set of building blocks including OAuth 2.0 and CoAP, thus making a well-known and widely used authorization solution suitable for IoT devices.  Existing specifications are used where possible, but where the constraints of IoT devices require it, extensions are added and profiles are defined.  </p>
-<h1 id="rfc.status">
-  <a href="#rfc.status">Status of This Memo</a>
-</h1>
+<h1 id="rfc.status"><a href="#rfc.status">Status of This Memo</a></h1>
 <p>This Internet-Draft is submitted in full conformance with the provisions of BCP 78 and BCP 79.</p>
-<p>Internet-Drafts are working documents of the Internet Engineering Task Force (IETF).  Note that other groups may also distribute working documents as Internet-Drafts.  The list of current Internet-Drafts is at http://datatracker.ietf.org/drafts/current/.</p>
+<p>Internet-Drafts are working documents of the Internet Engineering Task Force (IETF).  Note that other groups may also distribute working documents as Internet-Drafts.  The list of current Internet-Drafts is at https://datatracker.ietf.org/drafts/current/.</p>
 <p>Internet-Drafts are draft documents valid for a maximum of six months and may be updated, replaced, or obsoleted by other documents at any time.  It is inappropriate to use Internet-Drafts as reference material or to cite them other than as "work in progress."</p>
-<p>This Internet-Draft will expire on May 27, 2018.</p>
-<h1 id="rfc.copyrightnotice">
-  <a href="#rfc.copyrightnotice">Copyright Notice</a>
-</h1>
+<p>This Internet-Draft will expire on June 21, 2018.</p>
+<h1 id="rfc.copyrightnotice"><a href="#rfc.copyrightnotice">Copyright Notice</a></h1>
 <p>Copyright (c) 2017 IETF Trust and the persons identified as the document authors.  All rights reserved.</p>
-<p>This document is subject to BCP 78 and the IETF Trust's Legal Provisions Relating to IETF Documents (http://trustee.ietf.org/license-info) in effect on the date of publication of this document.  Please review these documents carefully, as they describe your rights and restrictions with respect to this document.  Code Components extracted from this document must include Simplified BSD License text as described in Section 4.e of the Trust Legal Provisions and are provided without warranty as described in the Simplified BSD License.</p>
+<p>This document is subject to BCP 78 and the IETF Trust's Legal Provisions Relating to IETF Documents (https://trustee.ietf.org/license-info) in effect on the date of publication of this document.  Please review these documents carefully, as they describe your rights and restrictions with respect to this document.  Code Components extracted from this document must include Simplified BSD License text as described in Section 4.e of the Trust Legal Provisions and are provided without warranty as described in the Simplified BSD License.</p>
 
   
   <hr class="noprint" />
   <h1 class="np" id="rfc.toc"><a href="#rfc.toc">Table of Contents</a></h1>
   <ul class="toc">
 
-  	<li>1.   <a href="#rfc.section.1">Introduction</a></li>
-<li>2.   <a href="#rfc.section.2">Terminology</a></li>
-<li>3.   <a href="#rfc.section.3">Overview</a></li>
-<ul><li>3.1.   <a href="#rfc.section.3.1">OAuth 2.0</a></li>
-<li>3.2.   <a href="#rfc.section.3.2">CoAP</a></li>
-</ul><li>4.   <a href="#rfc.section.4">Protocol Interactions</a></li>
-<li>5.   <a href="#rfc.section.5">Framework</a></li>
-<ul><li>5.1.   <a href="#rfc.section.5.1">Discovering Authorization Servers</a></li>
-<ul><li>5.1.1.   <a href="#rfc.section.5.1.1">Unauthorized Resource Request Message</a></li>
-<li>5.1.2.   <a href="#rfc.section.5.1.2">AS Information</a></li>
-</ul><li>5.2.   <a href="#rfc.section.5.2">Authorization Grants</a></li>
-<li>5.3.   <a href="#rfc.section.5.3">Client Credentials</a></li>
-<li>5.4.   <a href="#rfc.section.5.4">AS Authentication</a></li>
-<li>5.5.   <a href="#rfc.section.5.5">The Authorization Endpoint</a></li>
-<li>5.6.   <a href="#rfc.section.5.6">The Token Endpoint</a></li>
-<ul><li>5.6.1.   <a href="#rfc.section.5.6.1">Client-to-AS Request</a></li>
-<li>5.6.2.   <a href="#rfc.section.5.6.2">AS-to-Client Response</a></li>
-<li>5.6.3.   <a href="#rfc.section.5.6.3">Error Response</a></li>
-<li>5.6.4.   <a href="#rfc.section.5.6.4">Request and Response Parameters</a></li>
-<ul><li>5.6.4.1.   <a href="#rfc.section.5.6.4.1">Audience</a></li>
-<li>5.6.4.2.   <a href="#rfc.section.5.6.4.2">Grant Type</a></li>
-<li>5.6.4.3.   <a href="#rfc.section.5.6.4.3">Token Type</a></li>
-<li>5.6.4.4.   <a href="#rfc.section.5.6.4.4">Profile</a></li>
-<li>5.6.4.5.   <a href="#rfc.section.5.6.4.5">Confirmation</a></li>
-</ul><li>5.6.5.   <a href="#rfc.section.5.6.5">Mapping parameters to CBOR</a></li>
-</ul><li>5.7.   <a href="#rfc.section.5.7">The 'Introspect' Endpoint</a></li>
-<ul><li>5.7.1.   <a href="#rfc.section.5.7.1">RS-to-AS Request</a></li>
-<li>5.7.2.   <a href="#rfc.section.5.7.2">AS-to-RS Response</a></li>
-<li>5.7.3.   <a href="#rfc.section.5.7.3">Error Response</a></li>
-<li>5.7.4.   <a href="#rfc.section.5.7.4">Client Token</a></li>
-<li>5.7.5.   <a href="#rfc.section.5.7.5">Mapping Introspection parameters to CBOR</a></li>
-</ul><li>5.8.   <a href="#rfc.section.5.8">The Access Token</a></li>
-<ul><li>5.8.1.   <a href="#rfc.section.5.8.1">The 'Authorization Information' Endpoint</a></li>
-<li>5.8.2.   <a href="#rfc.section.5.8.2">Token Expiration</a></li>
-</ul></ul><li>6.   <a href="#rfc.section.6">Security Considerations</a></li>
-<ul><li>6.1.   <a href="#rfc.section.6.1">Unprotected AS Information</a></li>
-<li>6.2.   <a href="#rfc.section.6.2">Use of Nonces for Replay Protection</a></li>
-<li>6.3.   <a href="#rfc.section.6.3">Combining profiles</a></li>
-<li>6.4.   <a href="#rfc.section.6.4">Error responses</a></li>
-</ul><li>7.   <a href="#rfc.section.7">Privacy Considerations</a></li>
-<li>8.   <a href="#rfc.section.8">IANA Considerations</a></li>
-<ul><li>8.1.   <a href="#rfc.section.8.1">Authorization Server Information</a></li>
-<li>8.2.   <a href="#rfc.section.8.2">OAuth Error Code CBOR Mappings Registry</a></li>
-<li>8.3.   <a href="#rfc.section.8.3">OAuth Grant Type CBOR Mappings</a></li>
-<li>8.4.   <a href="#rfc.section.8.4">OAuth Access Token Types</a></li>
-<li>8.5.   <a href="#rfc.section.8.5">OAuth Token Type CBOR Mappings</a></li>
-<ul><li>8.5.1.   <a href="#rfc.section.8.5.1">Initial Registry Contents</a></li>
-</ul><li>8.6.   <a href="#rfc.section.8.6">ACE OAuth Profile Registry</a></li>
-<li>8.7.   <a href="#rfc.section.8.7">OAuth Parameter Registration</a></li>
-<li>8.8.   <a href="#rfc.section.8.8">OAuth CBOR Parameter Mappings Registry</a></li>
-<li>8.9.   <a href="#rfc.section.8.9">OAuth Introspection Response Parameter Registration</a></li>
-<li>8.10.   <a href="#rfc.section.8.10">Introspection Endpoint CBOR Mappings Registry</a></li>
-<li>8.11.   <a href="#rfc.section.8.11">JSON Web Token Claims</a></li>
-<li>8.12.   <a href="#rfc.section.8.12">CBOR Web Token Claims</a></li>
-<li>8.13.   <a href="#rfc.section.8.13">CoAP Option Number Registration</a></li>
-</ul><li>9.   <a href="#rfc.section.9">Acknowledgments</a></li>
-<li>10.   <a href="#rfc.references">References</a></li>
-<ul><li>10.1.   <a href="#rfc.references.1">Normative References</a></li>
-<li>10.2.   <a href="#rfc.references.2">Informative References</a></li>
-</ul><li>Appendix A.   <a href="#rfc.appendix.A">Design Justification</a></li>
-<li>Appendix B.   <a href="#rfc.appendix.B">Roles and Responsibilities</a></li>
-<li>Appendix C.   <a href="#rfc.appendix.C">Requirements on Profiles</a></li>
-<li>Appendix D.   <a href="#rfc.appendix.D">Assumptions on AS knowledge about C and RS</a></li>
-<li>Appendix E.   <a href="#rfc.appendix.E">Deployment Examples</a></li>
-<ul><li>E.1.   <a href="#rfc.appendix.E.1">Local Token Validation</a></li>
-<li>E.2.   <a href="#rfc.appendix.E.2">Introspection Aided Token Validation</a></li>
-</ul><li>Appendix F.   <a href="#rfc.appendix.F">Document Updates</a></li>
-<ul><li>F.1.   <a href="#rfc.appendix.F.1">Version -09 to -10</a></li>
-<li>F.2.   <a href="#rfc.appendix.F.2">Version -08 to -09</a></li>
-<li>F.3.   <a href="#rfc.appendix.F.3">Version -07 to -08</a></li>
-<li>F.4.   <a href="#rfc.appendix.F.4">Version -06 to -07</a></li>
-<li>F.5.   <a href="#rfc.appendix.F.5">Version -05 to -06</a></li>
-<li>F.6.   <a href="#rfc.appendix.F.6">Version -04 to -05</a></li>
-<li>F.7.   <a href="#rfc.appendix.F.7">Version -03 to -04</a></li>
-<li>F.8.   <a href="#rfc.appendix.F.8">Version -02 to -03</a></li>
-<li>F.9.   <a href="#rfc.appendix.F.9">Version -01 to -02</a></li>
-<li>F.10.   <a href="#rfc.appendix.F.10">Version -00 to -01</a></li>
-</ul><li><a href="#rfc.authors">Authors' Addresses</a></li>
+  	<li>1.   <a href="#rfc.section.1">Introduction</a>
+</li>
+<li>2.   <a href="#rfc.section.2">Terminology</a>
+</li>
+<li>3.   <a href="#rfc.section.3">Overview</a>
+</li>
+<ul><li>3.1.   <a href="#rfc.section.3.1">OAuth 2.0</a>
+</li>
+<li>3.2.   <a href="#rfc.section.3.2">CoAP</a>
+</li>
+</ul><li>4.   <a href="#rfc.section.4">Protocol Interactions</a>
+</li>
+<li>5.   <a href="#rfc.section.5">Framework</a>
+</li>
+<ul><li>5.1.   <a href="#rfc.section.5.1">Discovering Authorization Servers</a>
+</li>
+<ul><li>5.1.1.   <a href="#rfc.section.5.1.1">Unauthorized Resource Request Message</a>
+</li>
+<li>5.1.2.   <a href="#rfc.section.5.1.2">AS Information</a>
+</li>
+</ul><li>5.2.   <a href="#rfc.section.5.2">Authorization Grants</a>
+</li>
+<li>5.3.   <a href="#rfc.section.5.3">Client Credentials</a>
+</li>
+<li>5.4.   <a href="#rfc.section.5.4">AS Authentication</a>
+</li>
+<li>5.5.   <a href="#rfc.section.5.5">The Authorization Endpoint</a>
+</li>
+<li>5.6.   <a href="#rfc.section.5.6">The Token Endpoint</a>
+</li>
+<ul><li>5.6.1.   <a href="#rfc.section.5.6.1">Client-to-AS Request</a>
+</li>
+<li>5.6.2.   <a href="#rfc.section.5.6.2">AS-to-Client Response</a>
+</li>
+<li>5.6.3.   <a href="#rfc.section.5.6.3">Error Response</a>
+</li>
+<li>5.6.4.   <a href="#rfc.section.5.6.4">Request and Response Parameters</a>
+</li>
+<ul><li>5.6.4.1.   <a href="#rfc.section.5.6.4.1">Audience</a>
+</li>
+<li>5.6.4.2.   <a href="#rfc.section.5.6.4.2">Grant Type</a>
+</li>
+<li>5.6.4.3.   <a href="#rfc.section.5.6.4.3">Token Type</a>
+</li>
+<li>5.6.4.4.   <a href="#rfc.section.5.6.4.4">Profile</a>
+</li>
+<li>5.6.4.5.   <a href="#rfc.section.5.6.4.5">Confirmation</a>
+</li>
+</ul><li>5.6.5.   <a href="#rfc.section.5.6.5">Mapping Parameters to CBOR</a>
+</li>
+</ul><li>5.7.   <a href="#rfc.section.5.7">The 'Introspect' Endpoint</a>
+</li>
+<ul><li>5.7.1.   <a href="#rfc.section.5.7.1">RS-to-AS Request</a>
+</li>
+<li>5.7.2.   <a href="#rfc.section.5.7.2">AS-to-RS Response</a>
+</li>
+<li>5.7.3.   <a href="#rfc.section.5.7.3">Error Response</a>
+</li>
+<li>5.7.4.   <a href="#rfc.section.5.7.4">Client Token</a>
+</li>
+<li>5.7.5.   <a href="#rfc.section.5.7.5">Mapping Introspection parameters to CBOR</a>
+</li>
+</ul><li>5.8.   <a href="#rfc.section.5.8">The Access Token</a>
+</li>
+<ul><li>5.8.1.   <a href="#rfc.section.5.8.1">The 'Authorization Information' Endpoint</a>
+</li>
+<li>5.8.2.   <a href="#rfc.section.5.8.2">Token Expiration</a>
+</li>
+</ul></ul><li>6.   <a href="#rfc.section.6">Security Considerations</a>
+</li>
+<ul><li>6.1.   <a href="#rfc.section.6.1">Unprotected AS Information</a>
+</li>
+<li>6.2.   <a href="#rfc.section.6.2">Use of Nonces for Replay Protection</a>
+</li>
+<li>6.3.   <a href="#rfc.section.6.3">Combining profiles</a>
+</li>
+<li>6.4.   <a href="#rfc.section.6.4">Error responses</a>
+</li>
+</ul><li>7.   <a href="#rfc.section.7">Privacy Considerations</a>
+</li>
+<li>8.   <a href="#rfc.section.8">IANA Considerations</a>
+</li>
+<ul><li>8.1.   <a href="#rfc.section.8.1">Authorization Server Information</a>
+</li>
+<li>8.2.   <a href="#rfc.section.8.2">OAuth Error Code CBOR Mappings Registry</a>
+</li>
+<li>8.3.   <a href="#rfc.section.8.3">OAuth Grant Type CBOR Mappings</a>
+</li>
+<li>8.4.   <a href="#rfc.section.8.4">OAuth Access Token Types</a>
+</li>
+<li>8.5.   <a href="#rfc.section.8.5">OAuth Token Type CBOR Mappings</a>
+</li>
+<ul><li>8.5.1.   <a href="#rfc.section.8.5.1">Initial Registry Contents</a>
+</li>
+</ul><li>8.6.   <a href="#rfc.section.8.6">ACE OAuth Profile Registry</a>
+</li>
+<li>8.7.   <a href="#rfc.section.8.7">OAuth Parameter Registration</a>
+</li>
+<li>8.8.   <a href="#rfc.section.8.8">OAuth CBOR Parameter Mappings Registry</a>
+</li>
+<li>8.9.   <a href="#rfc.section.8.9">OAuth Introspection Response Parameter Registration</a>
+</li>
+<li>8.10.   <a href="#rfc.section.8.10">Introspection Endpoint CBOR Mappings Registry</a>
+</li>
+<li>8.11.   <a href="#rfc.section.8.11">JSON Web Token Claims</a>
+</li>
+<li>8.12.   <a href="#rfc.section.8.12">CBOR Web Token Claims</a>
+</li>
+<li>8.13.   <a href="#rfc.section.8.13">CoAP Option Number Registration</a>
+</li>
+</ul><li>9.   <a href="#rfc.section.9">Acknowledgments</a>
+</li>
+<li>10.   <a href="#rfc.references">References</a>
+</li>
+<ul><li>10.1.   <a href="#rfc.references.1">Normative References</a>
+</li>
+<li>10.2.   <a href="#rfc.references.2">Informative References</a>
+</li>
+</ul><li>Appendix A.   <a href="#rfc.appendix.A">Design Justification</a>
+</li>
+<li>Appendix B.   <a href="#rfc.appendix.B">Roles and Responsibilities</a>
+</li>
+<li>Appendix C.   <a href="#rfc.appendix.C">Requirements on Profiles</a>
+</li>
+<li>Appendix D.   <a href="#rfc.appendix.D">Assumptions on AS knowledge about C and RS</a>
+</li>
+<li>Appendix E.   <a href="#rfc.appendix.E">Deployment Examples</a>
+</li>
+<ul><li>E.1.   <a href="#rfc.appendix.E.1">Local Token Validation</a>
+</li>
+<li>E.2.   <a href="#rfc.appendix.E.2">Introspection Aided Token Validation</a>
+</li>
+</ul><li>Appendix F.   <a href="#rfc.appendix.F">Document Updates</a>
+</li>
+<ul><li>F.1.   <a href="#rfc.appendix.F.1">Version -09 to -10</a>
+</li>
+<li>F.2.   <a href="#rfc.appendix.F.2">Version -08 to -09</a>
+</li>
+<li>F.3.   <a href="#rfc.appendix.F.3">Version -07 to -08</a>
+</li>
+<li>F.4.   <a href="#rfc.appendix.F.4">Version -06 to -07</a>
+</li>
+<li>F.5.   <a href="#rfc.appendix.F.5">Version -05 to -06</a>
+</li>
+<li>F.6.   <a href="#rfc.appendix.F.6">Version -04 to -05</a>
+</li>
+<li>F.7.   <a href="#rfc.appendix.F.7">Version -03 to -04</a>
+</li>
+<li>F.8.   <a href="#rfc.appendix.F.8">Version -02 to -03</a>
+</li>
+<li>F.9.   <a href="#rfc.appendix.F.9">Version -01 to -02</a>
+</li>
+<li>F.10.   <a href="#rfc.appendix.F.10">Version -00 to -01</a>
+</li>
+</ul><li><a href="#rfc.authors">Authors' Addresses</a>
+</li>
 
 
   </ul>
 
-  <h1 id="rfc.section.1"><a href="#rfc.section.1">1.</a> <a href="#intro" id="intro">Introduction</a></h1>
-<p id="rfc.section.1.p.1">Authorization is the process for granting approval to an entity to access a resource <a href="#RFC4949">[RFC4949]</a>. The authorization task itself can best be described as granting access to a requesting client, for a resource hosted on a device, the resource server (RS).  This exchange is mediated by one or multiple authorization servers (AS). Managing authorization for a large number of devices and users can be a complex task. </p>
-<p id="rfc.section.1.p.2">While prior work on authorization solutions for the Web and for the mobile environment also applies to the Internet of Things (IoT) environment, many IoT devices are constrained, for example, in terms of processing capabilities, available memory, etc. For web applications on constrained nodes, this specification RECOMMENDS the use of CoAP <a href="#RFC7252">[RFC7252]</a> as replacement for HTTP.</p>
-<p id="rfc.section.1.p.3">A detailed treatment of constraints can be found in <a href="#RFC7228">[RFC7228]</a>, and the different IoT deployments present a continuous range of device and network capabilities.  Taking energy consumption as an example: At one end there are energy-harvesting or battery powered devices which have a tight power budget, on the other end there are mains-powered devices, and all levels in between.</p>
-<p id="rfc.section.1.p.4">Hence, IoT devices may be very different in terms of available processing and message exchange capabilities and there is a need to support many different authorization use cases <a href="#RFC7744">[RFC7744]</a>.</p>
-<p id="rfc.section.1.p.5">This specification describes a framework for authentication and authorization in constrained environments (ACE) built on re-use of OAuth 2.0 <a href="#RFC6749">[RFC6749]</a>, thereby extending authorization to Internet of Things devices.  This specification contains the necessary building blocks for adjusting OAuth 2.0 to IoT environments.</p>
-<p id="rfc.section.1.p.6">More detailed, interoperable specifications can be found in profiles.  Implementations may claim conformance with a specific profile, whereby implementations utilizing the same profile interoperate while implementations of different profiles are not expected to be interoperable.  Some devices, such as mobile phones and tablets, may implement multiple profiles and will therefore be able to interact with a wider range of low end devices.  Requirements on profiles are described at contextually appropriate places throughout this specification, and also summarized in <a href="#app:profileRequirements">Appendix C</a>.  </p>
-<h1 id="rfc.section.2"><a href="#rfc.section.2">2.</a> <a href="#terminology" id="terminology">Terminology</a></h1>
-<p id="rfc.section.2.p.1">The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in <a href="#RFC2119">[RFC2119]</a>.  </p>
-<p id="rfc.section.2.p.2">Certain security-related terms such as "authentication", "authorization", "confidentiality", "(data) integrity", "message authentication code", and "verify" are taken from <a href="#RFC4949">[RFC4949]</a>.  </p>
-<p id="rfc.section.2.p.3">Since exchanges in this specification are described as RESTful protocol interactions, HTTP <a href="#RFC7231">[RFC7231]</a> offers useful terminology.  </p>
-<p id="rfc.section.2.p.4">Terminology for entities in the architecture is defined in OAuth 2.0 <a href="#RFC6749">[RFC6749]</a> and <a href="#I-D.ietf-ace-actors">[I-D.ietf-ace-actors]</a>, such as client (C), resource server (RS), and authorization server (AS).</p>
-<p id="rfc.section.2.p.5">Note that the term "endpoint" is used here following its OAuth definition, which is to denote resources such as token and introspection at the AS and authz-info at the RS (see <a href="#tokenAuthInfoEndpoint">Section 5.8.1</a> for a definition of the authz-info endpoint).  The CoAP <a href="#RFC7252">[RFC7252]</a> definition, which is "An entity participating in the CoAP protocol" is not used in this specification.</p>
-<p id="rfc.section.2.p.6">Since this specification focuses on the problem of access control to resources, the actors has been simplified by assuming that the client authorization server (CAS) functionality is not stand-alone but subsumed by either the authorization server or the client (see section 2.2 in <a href="#I-D.ietf-ace-actors">[I-D.ietf-ace-actors]</a>).  </p>
+  <h1 id="rfc.section.1">
+<a href="#rfc.section.1">1.</a> <a href="#intro" id="intro">Introduction</a>
+</h1>
+<p id="rfc.section.1.p.1">Authorization is the process for granting approval to an entity to access a resource <a href="#RFC4949" class="xref">[RFC4949]</a>. The authorization task itself can best be described as granting access to a requesting client, for a resource hosted on a device, the resource server (RS).  This exchange is mediated by one or multiple authorization servers (AS). Managing authorization for a large number of devices and users can be a complex task. </p>
+<p id="rfc.section.1.p.2">While prior work on authorization solutions for the Web and for the mobile environment also applies to the Internet of Things (IoT) environment, many IoT devices are constrained, for example, in terms of processing capabilities, available memory, etc. For web applications on constrained nodes, this specification RECOMMENDS the use of CoAP <a href="#RFC7252" class="xref">[RFC7252]</a> as replacement for HTTP.</p>
+<p id="rfc.section.1.p.3">A detailed treatment of constraints can be found in <a href="#RFC7228" class="xref">[RFC7228]</a>, and the different IoT deployments present a continuous range of device and network capabilities.  Taking energy consumption as an example: At one end there are energy-harvesting or battery powered devices which have a tight power budget, on the other end there are mains-powered devices, and all levels in between.</p>
+<p id="rfc.section.1.p.4">Hence, IoT devices may be very different in terms of available processing and message exchange capabilities and there is a need to support many different authorization use cases <a href="#RFC7744" class="xref">[RFC7744]</a>.</p>
+<p id="rfc.section.1.p.5">This specification describes a framework for authentication and authorization in constrained environments (ACE) built on re-use of OAuth 2.0 <a href="#RFC6749" class="xref">[RFC6749]</a>, thereby extending authorization to Internet of Things devices.  This specification contains the necessary building blocks for adjusting OAuth 2.0 to IoT environments.</p>
+<p id="rfc.section.1.p.6">More detailed, interoperable specifications can be found in profiles.  Implementations may claim conformance with a specific profile, whereby implementations utilizing the same profile interoperate while implementations of different profiles are not expected to be interoperable.  Some devices, such as mobile phones and tablets, may implement multiple profiles and will therefore be able to interact with a wider range of low end devices.  Requirements on profiles are described at contextually appropriate places throughout this specification, and also summarized in <a href="#app:profileRequirements" class="xref">Appendix C</a>.  </p>
+<h1 id="rfc.section.2">
+<a href="#rfc.section.2">2.</a> <a href="#terminology" id="terminology">Terminology</a>
+</h1>
+<p id="rfc.section.2.p.1">The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in <a href="#RFC2119" class="xref">[RFC2119]</a>.  </p>
+<p id="rfc.section.2.p.2">Certain security-related terms such as "authentication", "authorization", "confidentiality", "(data) integrity", "message authentication code", and "verify" are taken from <a href="#RFC4949" class="xref">[RFC4949]</a>.  </p>
+<p id="rfc.section.2.p.3">Since exchanges in this specification are described as RESTful protocol interactions, HTTP <a href="#RFC7231" class="xref">[RFC7231]</a> offers useful terminology.  </p>
+<p id="rfc.section.2.p.4">Terminology for entities in the architecture is defined in OAuth 2.0 <a href="#RFC6749" class="xref">[RFC6749]</a> and <a href="#I-D.ietf-ace-actors" class="xref">[I-D.ietf-ace-actors]</a>, such as client (C), resource server (RS), and authorization server (AS).</p>
+<p id="rfc.section.2.p.5">Note that the term "endpoint" is used here following its OAuth definition, which is to denote resources such as token and introspection at the AS and authz-info at the RS (see <a href="#tokenAuthInfoEndpoint" class="xref">Section 5.8.1</a> for a definition of the authz-info endpoint).  The CoAP <a href="#RFC7252" class="xref">[RFC7252]</a> definition, which is "An entity participating in the CoAP protocol" is not used in this specification.</p>
+<p id="rfc.section.2.p.6">Since this specification focuses on the problem of access control to resources, the actors has been simplified by assuming that the client authorization server (CAS) functionality is not stand-alone but subsumed by either the authorization server or the client (see Section 2.2 in <a href="#I-D.ietf-ace-actors" class="xref">[I-D.ietf-ace-actors]</a>).  </p>
 <p id="rfc.section.2.p.7">The specifications in this document is called the "framework" or "ACE framework".  When referring to "profiles of this framework" it refers to additional specifications that define the use of this specification with concrete transport, and communication security protocols (e.g., CoAP over DTLS).  </p>
 <p id="rfc.section.2.p.8">We use the term "RS Information" for parameters describing characteristics of the RS (e.g. public key) that the AS provides to the client.</p>
-<h1 id="rfc.section.3"><a href="#rfc.section.3">3.</a> <a href="#overview" id="overview">Overview</a></h1>
+<h1 id="rfc.section.3">
+<a href="#rfc.section.3">3.</a> <a href="#overview" id="overview">Overview</a>
+</h1>
 <p id="rfc.section.3.p.1">This specification defines the ACE framework for authorization in the Internet of Things environment. It consists of a set of building blocks.</p>
-<p id="rfc.section.3.p.2">The basic block is the OAuth 2.0 <a href="#RFC6749">[RFC6749]</a> framework, which enjoys widespread deployment.  Many IoT devices can support OAuth 2.0 without any additional extensions, but for certain constrained settings additional profiling is needed.  </p>
-<p id="rfc.section.3.p.3">Another building block is the lightweight web transfer protocol CoAP <a href="#RFC7252">[RFC7252]</a>, for those communication environments where HTTP is not appropriate.  CoAP typically runs on top of UDP, which further reduces overhead and message exchanges. While this specification defines extensions for the use of OAuth over CoAP, other underlying protocols are not prohibited from being supported in the future, such as HTTP/2, MQTT, BLE and QUIC.</p>
-<p id="rfc.section.3.p.4">A third building block is CBOR <a href="#RFC7049">[RFC7049]</a>, for encodings where JSON <a href="#RFC7159">[RFC7159]</a> is not sufficiently compact.  CBOR is a binary encoding designed for small code and message size, which may be used for encoding of self contained tokens, and also for encoding payload transferred in protocol messages.  </p>
-<p id="rfc.section.3.p.5">A fourth building block is the compact CBOR-based secure message format COSE <a href="#RFC8152">[RFC8152]</a>, which enables application layer security as an alternative or complement to transport layer security (DTLS <a href="#RFC6347">[RFC6347]</a> or TLS <a href="#RFC5246">[RFC5246]</a>). COSE is used to secure self-contained tokens such as proof-of-possession (PoP) tokens, which is an extension to the OAuth tokens, and "client tokens" which are defined in this framework (see <a href="#clientToken">Section 5.7.4</a>). The default token format is defined in CBOR web token (CWT) <a href="#I-D.ietf-ace-cbor-web-token">[I-D.ietf-ace-cbor-web-token]</a>.  Application layer security for CoAP using COSE can be provided with OSCOAP <a href="#I-D.ietf-core-object-security">[I-D.ietf-core-object-security]</a>.</p>
-<p id="rfc.section.3.p.6">With the building blocks listed above, solutions satisfying various IoT device and network constraints are possible.  A list of constraints is described in detail in RFC 7228 <a href="#RFC7228">[RFC7228]</a> and a description of how the building blocks mentioned above relate to the various constraints can be found in <a href="#constraints">Appendix A</a>.</p>
+<p id="rfc.section.3.p.2">The basic block is the OAuth 2.0 <a href="#RFC6749" class="xref">[RFC6749]</a> framework, which enjoys widespread deployment.  Many IoT devices can support OAuth 2.0 without any additional extensions, but for certain constrained settings additional profiling is needed.  </p>
+<p id="rfc.section.3.p.3">Another building block is the lightweight web transfer protocol CoAP <a href="#RFC7252" class="xref">[RFC7252]</a>, for those communication environments where HTTP is not appropriate.  CoAP typically runs on top of UDP, which further reduces overhead and message exchanges. While this specification defines extensions for the use of OAuth over CoAP, other underlying protocols are not prohibited from being supported in the future, such as HTTP/2, MQTT, BLE and QUIC.</p>
+<p id="rfc.section.3.p.4">A third building block is CBOR <a href="#RFC7049" class="xref">[RFC7049]</a>, for encodings where JSON <a href="#RFC7159" class="xref">[RFC7159]</a> is not sufficiently compact.  CBOR is a binary encoding designed for small code and message size, which may be used for encoding of self contained tokens, and also for encoding payload transferred in protocol messages.  </p>
+<p id="rfc.section.3.p.5">A fourth building block is the compact CBOR-based secure message format COSE <a href="#RFC8152" class="xref">[RFC8152]</a>, which enables application layer security as an alternative or complement to transport layer security (DTLS <a href="#RFC6347" class="xref">[RFC6347]</a> or TLS <a href="#RFC5246" class="xref">[RFC5246]</a>). COSE is used to secure self-contained tokens such as proof-of-possession (PoP) tokens, which is an extension to the OAuth tokens, and "client tokens" which are defined in this framework (see <a href="#clientToken" class="xref">Section 5.7.4</a>). The default token format is defined in CBOR web token (CWT) <a href="#I-D.ietf-ace-cbor-web-token" class="xref">[I-D.ietf-ace-cbor-web-token]</a>.  Application layer security for CoAP using COSE can be provided with OSCOAP <a href="#I-D.ietf-core-object-security" class="xref">[I-D.ietf-core-object-security]</a>.</p>
+<p id="rfc.section.3.p.6">With the building blocks listed above, solutions satisfying various IoT device and network constraints are possible.  A list of constraints is described in detail in RFC 7228 <a href="#RFC7228" class="xref">[RFC7228]</a> and a description of how the building blocks mentioned above relate to the various constraints can be found in <a href="#constraints" class="xref">Appendix A</a>.</p>
 <p id="rfc.section.3.p.7">Luckily, not every IoT device suffers from all constraints.  The ACE framework nevertheless takes all these aspects into account and allows several different deployment variants to co-exist, rather than mandating a one-size-fits-all solution.  It is important to cover the wide range of possible interworking use cases and the different requirements from a security point of view.  Once IoT deployments mature, popular deployment variants will be documented in the form of ACE profiles.</p>
-<h1 id="rfc.section.3.1"><a href="#rfc.section.3.1">3.1.</a> <a href="#oauth2Overview" id="oauth2Overview">OAuth 2.0</a></h1>
+<h1 id="rfc.section.3.1">
+<a href="#rfc.section.3.1">3.1.</a> <a href="#oauth2Overview" id="oauth2Overview">OAuth 2.0</a>
+</h1>
 <p id="rfc.section.3.1.p.1">The OAuth 2.0 authorization framework enables a client to obtain scoped access to a resource with the permission of a resource owner.  Authorization information, or references to it, is passed between the nodes using access tokens.  These access tokens are issued to clients by an authorization server with the approval of the resource owner.  The client uses the access token to access the protected resources hosted by the resource server.</p>
 <p id="rfc.section.3.1.p.2">A number of OAuth 2.0 terms are used within this specification: </p>
 
 <dl>
-  <dt>The token and introspection Endpoints:</dt>
-  <dd style="margin-left: 8"><br/> The AS hosts the token endpoint that allows a client to request access tokens. The client makes a POST request to the token endpoint on the AS and receives the access token in the response (if the request was successful).  <br/> In some deployments, a token introspection endpoint is provided by the AS, which can be used by the RS if it needs to request additional information regarding a received access token.  The RS makes a POST request to the introspection endpoint on the AS and receives information about the access token in the response. (See "Introspection" below.) <br/><br/> </dd>
-  <dt>Access Tokens:</dt>
-  <dd style="margin-left: 8"><br/> Access tokens are credentials needed to access protected resources.  An access token is a data structure representing authorization permissions issued by the AS to the client.  Access tokens are generated by the AS and consumed by the RS.  The access token content is opaque to the client.  <br/><br/> Access tokens can have different formats, and various methods of utilization (e.g., cryptographic properties) based on the security requirements of the given deployment.  <br/><br/> </dd>
-  <dt>Proof of Possession Tokens:</dt>
-  <dd style="margin-left: 8"><br/> An access token may be bound to a cryptographic key, which is then used by an RS to authenticate requests from a client.  Such tokens are called proof-of-possession access tokens (or PoP access tokens).  <br/><br/> The proof-of-possession (PoP) security concept assumes that the AS acts as a trusted third party that binds keys to access tokens.  These so called PoP keys are then used by the client to demonstrate the possession of the secret to the RS when accessing the resource.  The RS, when receiving an access token, needs to verify that the key used by the client matches the one bound to the access token.  When this specification uses the term "access token" it is assumed to be a PoP access token token unless specifically stated otherwise.  <br/><br/> The key bound to the access token (the PoP key) may use either symmetric or asymmetric cryptography.  The appropriate choice of the kind of cryptography depends on the constraints of the IoT devices as well as on the security requirements of the use case.  <br/><br/> <dl><dt>Symmetric PoP key:</dt><dd style="margin-left: 8"><br/> The AS generates a random symmetric PoP key.  The key is either stored to be returned on introspection calls or encrypted and included in the access token.  The PoP key is also encrypted for the client and sent together with the access token to the client.<br/><br/> </dd><dt>Asymmetric PoP key:</dt><dd style="margin-left: 8"><br/> An asymmetric key pair is generated on the client and the public key is sent to the AS (if it does not already have knowledge of the client's public key).  Information about the public key, which is the PoP key in this case, is either stored to be returned on introspection calls or included inside the access token and sent back to the requesting client.  The RS can identify the client's public key from the information in the token, which allows the client to use the corresponding private key for the proof of possession.  </dd></dl><p> </p><br/><br/> The access token is either a simple reference, or a structured information object (e.g., CWT <a href="#I-D.ietf-ace-cbor-web-token">[I-D.ietf-ace-cbor-web-token]</a>), protected by a cryptographic wrapper (e.g., COSE <a href="#RFC8152">[RFC8152]</a>).  The choice of PoP key does not necessarily imply a specific credential type for the integrity protection of the token.<br/><br/> </dd>
-  <dt>Scopes and Permissions:</dt>
-  <dd style="margin-left: 8"><br/> In OAuth 2.0, the client specifies the type of permissions it is seeking to obtain (via the scope parameter) in the access token request.  In turn, the AS may use the scope response parameter to inform the client of the scope of the access token issued.  As the client could be a constrained device as well, this specification uses CBOR encoding as data format, defined in <a href="#oauthProfile">Section 5</a>, to request scopes and to be informed what scopes the access token actually authorizes.  <br/><br/> The values of the scope parameter in OAuth 2.0 are expressed as a list of space-delimited, case-sensitive strings, with a semantic that is well-known to the AS and the RS.  More details about the concept of scopes is found under Section 3.3 in <a href="#RFC6749">[RFC6749]</a>.<br/><br/> </dd>
-  <dt>Claims:</dt>
-  <dd style="margin-left: 8"><br/> Information carried in the access token or returned from introspection, called claims, is in the form of name-value pairs.  An access token may, for example, include a claim identifying the AS that issued the token (via the "iss" claim) and what audience the access token is intended for (via the "aud" claim).  The audience of an access token can be a specific resource or one or many resource servers.  The resource owner policies influence what claims are put into the access token by the authorization server.  <br/><br/> While the structure and encoding of the access token varies throughout deployments, a standardized format has been defined with the JSON Web Token (JWT) <a href="#RFC7519">[RFC7519]</a> where claims are encoded as a JSON object.  In <a href="#I-D.ietf-ace-cbor-web-token">[I-D.ietf-ace-cbor-web-token]</a>, an equivalent format using CBOR encoding (CWT) has been defined.  <br/><br/> </dd>
-  <dt>Introspection:</dt>
-  <dd style="margin-left: 8"><br/> Introspection is a method for a resource server to query the authorization server for the active state and content of a received access token.  This is particularly useful in those cases where the authorization decisions are very dynamic and/or where the received access token itself is an opaque reference rather than a self-contained token.   More information about introspection in OAuth 2.0 can be found in <a href="#RFC7662">[RFC7662]</a>.  </dd>
+<dt>The token and introspection Endpoints:</dt>
+<dd style="margin-left: 8">
+<br> The AS hosts the token endpoint that allows a client to request access tokens. The client makes a POST request to the token endpoint on the AS and receives the access token in the response (if the request was successful).  <br> In some deployments, a token introspection endpoint is provided by the AS, which can be used by the RS if it needs to request additional information regarding a received access token.  The RS makes a POST request to the introspection endpoint on the AS and receives information about the access token in the response. (See "Introspection" below.) <br><br> </dd>
+<dt>Access Tokens:</dt>
+<dd style="margin-left: 8">
+<br> Access tokens are credentials needed to access protected resources.  An access token is a data structure representing authorization permissions issued by the AS to the client.  Access tokens are generated by the AS and consumed by the RS.  The access token content is opaque to the client.  <br><br> Access tokens can have different formats, and various methods of utilization (e.g., cryptographic properties) based on the security requirements of the given deployment.  <br><br> </dd>
+<dt>Proof of Possession Tokens:</dt>
+<dd style="margin-left: 8">
+<br> An access token may be bound to a cryptographic key, which is then used by an RS to authenticate requests from a client.  Such tokens are called proof-of-possession access tokens (or PoP access tokens).  <br><br> The proof-of-possession (PoP) security concept assumes that the AS acts as a trusted third party that binds keys to access tokens.  These so called PoP keys are then used by the client to demonstrate the possession of the secret to the RS when accessing the resource.  The RS, when receiving an access token, needs to verify that the key used by the client matches the one bound to the access token.  When this specification uses the term "access token" it is assumed to be a PoP access token token unless specifically stated otherwise.  <br><br> The key bound to the access token (the PoP key) may use either symmetric or asymmetric cryptography.  The appropriate choice of the kind of cryptography depends on the constraints of the IoT devices as well as on the security requirements of the use case.  <br><br> <dl>
+<dt>Symmetric PoP key:</dt>
+<dd style="margin-left: 8">
+<br> The AS generates a random symmetric PoP key.  The key is either stored to be returned on introspection calls or encrypted and included in the access token.  The PoP key is also encrypted for the client and sent together with the access token to the client.<br><br> </dd>
+<dt>Asymmetric PoP key:</dt>
+<dd style="margin-left: 8">
+<br> An asymmetric key pair is generated on the client and the public key is sent to the AS (if it does not already have knowledge of the client's public key).  Information about the public key, which is the PoP key in this case, is either stored to be returned on introspection calls or included inside the access token and sent back to the requesting client.  The RS can identify the client's public key from the information in the token, which allows the client to use the corresponding private key for the proof of possession.  </dd>
+</dl>
+<p> </p>
+<br><br> The access token is either a simple reference, or a structured information object (e.g., CWT <a href="#I-D.ietf-ace-cbor-web-token" class="xref">[I-D.ietf-ace-cbor-web-token]</a>), protected by a cryptographic wrapper (e.g., COSE <a href="#RFC8152" class="xref">[RFC8152]</a>).  The choice of PoP key does not necessarily imply a specific credential type for the integrity protection of the token.<br><br> </dd>
+<dt>Scopes and Permissions:</dt>
+<dd style="margin-left: 8">
+<br> In OAuth 2.0, the client specifies the type of permissions it is seeking to obtain (via the scope parameter) in the access token request.  In turn, the AS may use the scope response parameter to inform the client of the scope of the access token issued.  As the client could be a constrained device as well, this specification uses CBOR encoding as data format, defined in <a href="#oauthProfile" class="xref">Section 5</a>, to request scopes and to be informed what scopes the access token actually authorizes.  <br><br> The values of the scope parameter in OAuth 2.0 are expressed as a list of space-delimited, case-sensitive strings, with a semantic that is well-known to the AS and the RS.  More details about the concept of scopes is found under Section 3.3 in <a href="#RFC6749" class="xref">[RFC6749]</a>.<br><br> </dd>
+<dt>Claims:</dt>
+<dd style="margin-left: 8">
+<br> Information carried in the access token or returned from introspection, called claims, is in the form of name-value pairs.  An access token may, for example, include a claim identifying the AS that issued the token (via the "iss" claim) and what audience the access token is intended for (via the "aud" claim).  The audience of an access token can be a specific resource or one or many resource servers.  The resource owner policies influence what claims are put into the access token by the authorization server.  <br><br> While the structure and encoding of the access token varies throughout deployments, a standardized format has been defined with the JSON Web Token (JWT) <a href="#RFC7519" class="xref">[RFC7519]</a> where claims are encoded as a JSON object.  In <a href="#I-D.ietf-ace-cbor-web-token" class="xref">[I-D.ietf-ace-cbor-web-token]</a>, an equivalent format using CBOR encoding (CWT) has been defined.  <br><br> </dd>
+<dt>Introspection:</dt>
+<dd style="margin-left: 8">
+<br> Introspection is a method for a resource server to query the authorization server for the active state and content of a received access token.  This is particularly useful in those cases where the authorization decisions are very dynamic and/or where the received access token itself is an opaque reference rather than a self-contained token.   More information about introspection in OAuth 2.0 can be found in <a href="#RFC7662" class="xref">[RFC7662]</a>.  </dd>
 </dl>
 
 <p> </p>
-<h1 id="rfc.section.3.2"><a href="#rfc.section.3.2">3.2.</a> <a href="#coap" id="coap">CoAP</a></h1>
+<h1 id="rfc.section.3.2">
+<a href="#rfc.section.3.2">3.2.</a> <a href="#coap" id="coap">CoAP</a>
+</h1>
 <p id="rfc.section.3.2.p.1">CoAP is an application layer protocol similar to HTTP, but specifically designed for constrained environments.  CoAP typically uses datagram-oriented transport, such as UDP, where reordering and loss of packets can occur.  A security solution needs to take the latter aspects into account.</p>
 <p id="rfc.section.3.2.p.2">While HTTP uses headers and query strings to convey additional information about a request, CoAP encodes such information into header parameters called 'options'.</p>
-<p id="rfc.section.3.2.p.3">CoAP supports application-layer fragmentation of the CoAP payloads through blockwise transfers <a href="#RFC7959">[RFC7959]</a>.  However, blockwise transfer does not increase the size limits of CoAP options, therefore data encoded in options has to be kept small.  </p>
-<p id="rfc.section.3.2.p.4">Transport layer security for CoAP can be provided by DTLS 1.2 <a href="#RFC6347">[RFC6347]</a> or TLS 1.2 <a href="#RFC5246">[RFC5246]</a>.  CoAP defines a number of proxy operations that require transport layer security to be terminated at the proxy. One approach for protecting CoAP communication end-to-end through proxies, and also to support security for CoAP over a different transport in a uniform way, is to provide security at the application layer using an object-based security mechanism such as COSE <a href="#RFC8152">[RFC8152]</a>.  </p>
-<p id="rfc.section.3.2.p.5">One application of COSE is OSCOAP <a href="#I-D.ietf-core-object-security">[I-D.ietf-core-object-security]</a>, which provides end-to-end confidentiality, integrity and replay protection, and a secure binding between CoAP request and response messages. In OSCOAP, the CoAP messages are wrapped in COSE objects and sent using CoAP.  </p>
+<p id="rfc.section.3.2.p.3">CoAP supports application-layer fragmentation of the CoAP payloads through blockwise transfers <a href="#RFC7959" class="xref">[RFC7959]</a>.  However, blockwise transfer does not increase the size limits of CoAP options, therefore data encoded in options has to be kept small.  </p>
+<p id="rfc.section.3.2.p.4">Transport layer security for CoAP can be provided by DTLS 1.2 <a href="#RFC6347" class="xref">[RFC6347]</a> or TLS 1.2 <a href="#RFC5246" class="xref">[RFC5246]</a>.  CoAP defines a number of proxy operations that require transport layer security to be terminated at the proxy. One approach for protecting CoAP communication end-to-end through proxies, and also to support security for CoAP over a different transport in a uniform way, is to provide security at the application layer using an object-based security mechanism such as COSE <a href="#RFC8152" class="xref">[RFC8152]</a>.  </p>
+<p id="rfc.section.3.2.p.5">One application of COSE is OSCOAP <a href="#I-D.ietf-core-object-security" class="xref">[I-D.ietf-core-object-security]</a>, which provides end-to-end confidentiality, integrity and replay protection, and a secure binding between CoAP request and response messages. In OSCOAP, the CoAP messages are wrapped in COSE objects and sent using CoAP.  </p>
 <p id="rfc.section.3.2.p.6">This framework RECOMMENDS the use of CoAP as replacement for HTTP.</p>
-<h1 id="rfc.section.4"><a href="#rfc.section.4">4.</a> <a href="#specs" id="specs">Protocol Interactions</a></h1>
-<p id="rfc.section.4.p.1">The ACE framework is based on the OAuth 2.0 protocol interactions using the token endpoint and optionally the introspection endpoint.  A client obtains an access token from an AS using the token endpoint and subsequently presents the access token to a RS to gain access to a protected resource. In most deployments the RS can process the access token locally, however in some cases the RS may present it to the AS via the introspection endpoint to get fresh information.  These interactions are shown in <a href="#fig:protocolFlow">Figure 1</a>.  An overview of various OAuth concepts is provided in <a href="#oauth2Overview">Section 3.1</a>.  </p>
-<p id="rfc.section.4.p.2">The OAuth 2.0 framework defines a number of "protocol flows" via grant types, which have been extended further with extensions to OAuth 2.0 (such as RFC 7521 <a href="#RFC7521">[RFC7521]</a> and <a href="#I-D.ietf-oauth-device-flow">[I-D.ietf-oauth-device-flow]</a>).  What grant types works best depends on the usage scenario and RFC 7744 <a href="#RFC7744">[RFC7744]</a> describes many different IoT use cases but there are two preferred grant types, namely the Authorization Code Grant (described in Section 4.1 of <a href="#RFC7521">[RFC7521]</a>) and the Client Credentials Grant (described in Section 4.4 of <a href="#RFC7521">[RFC7521]</a>). The Authorization Code Grant is a good fit for use with apps running on smart phones and tablets that request access to IoT devices, a common scenario in the smart home environment, where users need to go through an authentication and authorization phase (at least during the initial setup phase). The native apps guidelines described in <a href="#I-D.ietf-oauth-native-apps">[I-D.ietf-oauth-native-apps]</a> are applicable to this use case. The Client Credential Grant is a good fit for use with IoT devices where the OAuth client itself is constrained. In such a case, the resource owner has pre-arranged access rights for the client with the authorization server, which is often accomplished using a commissioning tool.</p>
-<p id="rfc.section.4.p.3">The consent of the resource owner, for giving a client access to a protected resource, can be provided dynamically as in the traditional OAuth flows, or it could be pre-configured by the resource owner as authorization policies at the AS, which the AS evaluates when a token request arrives.  The resource owner and the requesting party (i.e., client owner) are not shown in <a href="#fig:protocolFlow">Figure 1</a>.  </p>
+<h1 id="rfc.section.4">
+<a href="#rfc.section.4">4.</a> <a href="#specs" id="specs">Protocol Interactions</a>
+</h1>
+<p id="rfc.section.4.p.1">The ACE framework is based on the OAuth 2.0 protocol interactions using the token endpoint and optionally the introspection endpoint.  A client obtains an access token from an AS using the token endpoint and subsequently presents the access token to a RS to gain access to a protected resource. In most deployments the RS can process the access token locally, however in some cases the RS may present it to the AS via the introspection endpoint to get fresh information.  These interactions are shown in <a href="#fig:protocolFlow" class="xref">Figure 1</a>.  An overview of various OAuth concepts is provided in <a href="#oauth2Overview" class="xref">Section 3.1</a>.  </p>
+<p id="rfc.section.4.p.2">The OAuth 2.0 framework defines a number of "protocol flows" via grant types, which have been extended further with extensions to OAuth 2.0 (such as RFC 7521 <a href="#RFC7521" class="xref">[RFC7521]</a> and <a href="#I-D.ietf-oauth-device-flow" class="xref">[I-D.ietf-oauth-device-flow]</a>).  What grant types works best depends on the usage scenario and RFC 7744 <a href="#RFC7744" class="xref">[RFC7744]</a> describes many different IoT use cases but there are two preferred grant types, namely the Authorization Code Grant (described in Section 4.1 of <a href="#RFC7521" class="xref">[RFC7521]</a>) and the Client Credentials Grant (described in Section 4.4 of <a href="#RFC7521" class="xref">[RFC7521]</a>). The Authorization Code Grant is a good fit for use with apps running on smart phones and tablets that request access to IoT devices, a common scenario in the smart home environment, where users need to go through an authentication and authorization phase (at least during the initial setup phase). The native apps guidelines described in <a href="#I-D.ietf-oauth-native-apps" class="xref">[I-D.ietf-oauth-native-apps]</a> are applicable to this use case. The Client Credential Grant is a good fit for use with IoT devices where the OAuth client itself is constrained. In such a case, the resource owner has pre-arranged access rights for the client with the authorization server, which is often accomplished using a commissioning tool.</p>
+<p id="rfc.section.4.p.3">The consent of the resource owner, for giving a client access to a protected resource, can be provided dynamically as in the traditional OAuth flows, or it could be pre-configured by the resource owner as authorization policies at the AS, which the AS evaluates when a token request arrives.  The resource owner and the requesting party (i.e., client owner) are not shown in <a href="#fig:protocolFlow" class="xref">Figure 1</a>.  </p>
 <p id="rfc.section.4.p.4">This framework supports a wide variety of communication security mechanisms between the ACE entities, such as client, AS, and RS. It is assumed that the client has been registered (also called enrolled or onboarded) to an AS using a mechanism defined outside the scope of this document.  In practice, various techniques for onboarding have been used, such as factory-based provisioning or the use of commissioning tools. Regardless of the onboarding technique, this provisioning procedure implies that the client and the AS exchange credentials and configuration parameters.  These credentials are used to mutually authenticate each other and to protect messages exchanged between the client and the AS.</p>
 <p id="rfc.section.4.p.5">It is also assumed that the RS has been registered with the AS, potentially in a similar way as the client has been registered with the AS.  Established keying material between the AS and the RS allows the AS to apply cryptographic protection to the access token to ensure that its content cannot be modified, and if needed, that the content is confidentiality protected.</p>
 <p id="rfc.section.4.p.6">The keying material necessary for establishing communication security between C and RS is dynamically established as part of the protocol described in this document.  </p>
-<p id="rfc.section.4.p.7">At the start of the protocol, there is an optional discovery step where the client discovers the resource server and the resources this server hosts.  In this step, the client might also determine what permissions are needed to access the protected resource.  A generic procedure is described in <a href="#asDiscovery">Section 5.1</a>, profiles MAY define other procedures for discovery.</p>
-<p id="rfc.section.4.p.8">In Bluetooth Low Energy, for example, advertisements are broadcasted by a peripheral, including information about the primary services.  In CoAP, as a second example, a client can make a request to "/.well-known/core" to obtain information about available resources, which are returned in a standardized format as described in <a href="#RFC6690">[RFC6690]</a>.  </p>
-<div id="rfc.figure.1"/>
-<div id="fig:protocolFlow"/>
+<p id="rfc.section.4.p.7">At the start of the protocol, there is an optional discovery step where the client discovers the resource server and the resources this server hosts.  In this step, the client might also determine what permissions are needed to access the protected resource.  A generic procedure is described in <a href="#asDiscovery" class="xref">Section 5.1</a>, profiles MAY define other procedures for discovery.</p>
+<p id="rfc.section.4.p.8">In Bluetooth Low Energy, for example, advertisements are broadcasted by a peripheral, including information about the primary services.  In CoAP, as a second example, a client can make a request to "/.well-known/core" to obtain information about available resources, which are returned in a standardized format as described in <a href="#RFC6690" class="xref">[RFC6690]</a>.  </p>
+<div id="rfc.figure.1"></div>
+<div id="fig:protocolFlow"></div>
 <pre>
 +--------+                               +---------------+
 |        |---(A)-- Token Request -------&gt;|               |
@@ -708,65 +807,87 @@
 +--------+                               +--------------+
   </pre>
 <p class="figure">Figure 1: Basic Protocol Flow.</p>
-<p/>
-<p/>
+<p></p>
+<p></p>
 
 <dl>
-  <dt>Requesting an Access Token (A):</dt>
-  <dd style="margin-left: 8"><br/> The client makes an access token request to the token endpoint at the AS.  This framework assumes the use of PoP access tokens (see <a href="#oauth2Overview">Section 3.1</a> for a short description) wherein the AS binds a key to an access token.  The client may include permissions it seeks to obtain, and information about the credentials it wants to use (e.g., symmetric/asymmetric cryptography or a reference to a specific credential).<br/><br/> </dd>
-  <dt>Access Token Response (B):</dt>
-  <dd style="margin-left: 8"><br/> If the AS successfully processes the request from the client, it returns an access token.  It can also return additional parameters, referred to as "RS Information".  In addition to the response parameters defined by OAuth 2.0 and the PoP access token extension, this framework defines parameters that can be used to inform the client about capabilities of the RS. More information about these parameters can be found in <a href="#tokenParams">Section 5.6.4</a>.  <br/><br/> </dd>
-  <dt>Resource Request (C):</dt>
-  <dd style="margin-left: 8"><br/> The client interacts with the RS to request access to the protected resource and provides the access token.  The protocol to use between the client and the RS is not restricted to CoAP. HTTP, HTTP/2, QUIC, MQTT, Bluetooth Low Energy, etc., are also viable candidates.  <br/><br/> Depending on the device limitations and the selected protocol, this exchange may be split up into two parts: <ul class="empty"><li>(1) the client sends the access token containing, or referencing, the authorization information to the RS, that may be used for subsequent resource requests by the client, and </li><li>(2) the client makes the resource access request, using the communication security protocol and other RS Information obtained from the AS.</li></ul><p> </p><br/><br/> The Client and the RS mutually authenticate using the security protocol specified in the profile (see step B) and the keys obtained in the access token or the RS Information or the client token.  The RS verifies that the token is integrity protected by the AS and compares the claims contained in the access token with the resource request. If the RS is online, validation can be handed over to the AS using token introspection (see messages D and E) over HTTP or CoAP, in  which case the different parts of step C may be interleaved with introspection.<br/><br/> </dd>
-  <dt>Token Introspection Request (D):</dt>
-  <dd style="margin-left: 8"><br/> A resource server may be configured to introspect the access token by including it in a request to the introspection endpoint at that AS.  Token introspection over CoAP is defined in <a href="#introspectionEndpoint">Section 5.7</a> and for HTTP in <a href="#RFC7662">[RFC7662]</a>.  <br/><br/> Note that token introspection is an optional step and can be omitted if the token is self-contained and the resource server is prepared to perform the token validation on its own.<br/><br/> </dd>
-  <dt>Token Introspection Response (E):</dt>
-  <dd style="margin-left: 8"><br/> The AS validates the token and returns the most recent parameters, such as scope, audience, validity etc. associated with it back to the RS.  The RS then uses the received parameters to process the request to either accept or to deny it. The AS can additionally return information that the RS needs to pass on to the client in the form of a client token.  The latter is used to establish keys for mutual authentication between client and RS, when the client has no direct connectivity to the AS, see <a href="#clientToken">Section 5.7.4</a> for details.<br/><br/> </dd>
-  <dt>Protected Resource (F):</dt>
-  <dd style="margin-left: 8"><br/> If the request from the client is authorized, the RS fulfills the request and returns a response with the appropriate response code.  The RS uses the dynamically established keys to protect the response, according to used communication security protocol.  </dd>
+<dt>Requesting an Access Token (A):</dt>
+<dd style="margin-left: 8">
+<br> The client makes an access token request to the token endpoint at the AS.  This framework assumes the use of PoP access tokens (see <a href="#oauth2Overview" class="xref">Section 3.1</a> for a short description) wherein the AS binds a key to an access token.  The client may include permissions it seeks to obtain, and information about the credentials it wants to use (e.g., symmetric/asymmetric cryptography or a reference to a specific credential).<br><br> </dd>
+<dt>Access Token Response (B):</dt>
+<dd style="margin-left: 8">
+<br> If the AS successfully processes the request from the client, it returns an access token.  It can also return additional parameters, referred to as "RS Information".  In addition to the response parameters defined by OAuth 2.0 and the PoP access token extension, this framework defines parameters that can be used to inform the client about capabilities of the RS. More information about these parameters can be found in <a href="#tokenParams" class="xref">Section 5.6.4</a>.  <br><br> </dd>
+<dt>Resource Request (C):</dt>
+<dd style="margin-left: 8">
+<br> The client interacts with the RS to request access to the protected resource and provides the access token.  The protocol to use between the client and the RS is not restricted to CoAP. HTTP, HTTP/2, QUIC, MQTT, Bluetooth Low Energy, etc., are also viable candidates.  <br><br> Depending on the device limitations and the selected protocol, this exchange may be split up into two parts: <ul class="empty">
+<li>(1) the client sends the access token containing, or referencing, the authorization information to the RS, that may be used for subsequent resource requests by the client, and </li>
+<li>(2) the client makes the resource access request, using the communication security protocol and other RS Information obtained from the AS.</li>
+</ul>
+<p> </p>
+<br><br> The Client and the RS mutually authenticate using the security protocol specified in the profile (see step B) and the keys obtained in the access token or the RS Information or the client token.  The RS verifies that the token is integrity protected by the AS and compares the claims contained in the access token with the resource request. If the RS is online, validation can be handed over to the AS using token introspection (see messages D and E) over HTTP or CoAP, in  which case the different parts of step C may be interleaved with introspection.<br><br> </dd>
+<dt>Token Introspection Request (D):</dt>
+<dd style="margin-left: 8">
+<br> A resource server may be configured to introspect the access token by including it in a request to the introspection endpoint at that AS.  Token introspection over CoAP is defined in <a href="#introspectionEndpoint" class="xref">Section 5.7</a> and for HTTP in <a href="#RFC7662" class="xref">[RFC7662]</a>.  <br><br> Note that token introspection is an optional step and can be omitted if the token is self-contained and the resource server is prepared to perform the token validation on its own.<br><br> </dd>
+<dt>Token Introspection Response (E):</dt>
+<dd style="margin-left: 8">
+<br> The AS validates the token and returns the most recent parameters, such as scope, audience, validity etc. associated with it back to the RS.  The RS then uses the received parameters to process the request to either accept or to deny it. The AS can additionally return information that the RS needs to pass on to the client in the form of a client token.  The latter is used to establish keys for mutual authentication between client and RS, when the client has no direct connectivity to the AS, see <a href="#clientToken" class="xref">Section 5.7.4</a> for details.<br><br> </dd>
+<dt>Protected Resource (F):</dt>
+<dd style="margin-left: 8">
+<br> If the request from the client is authorized, the RS fulfills the request and returns a response with the appropriate response code.  The RS uses the dynamically established keys to protect the response, according to used communication security protocol.  </dd>
 </dl>
 
 <p> </p>
-<h1 id="rfc.section.5"><a href="#rfc.section.5">5.</a> <a href="#oauthProfile" id="oauthProfile">Framework</a></h1>
+<h1 id="rfc.section.5">
+<a href="#rfc.section.5">5.</a> <a href="#oauthProfile" id="oauthProfile">Framework</a>
+</h1>
 <p id="rfc.section.5.p.1">The following sections detail the profiling and extensions of OAuth 2.0 for constrained environments, which constitutes the ACE framework.  </p>
-<p/>
+<p></p>
 
 <dl>
-  <dt>Credential Provisioning</dt>
-  <dd style="margin-left: 8"><br/> For IoT, it cannot be assumed that the client and RS are part of a common key infrastructure, so the AS provisions credentials or associated information to allow mutual authentication. These credentials need to be provided to the parties before or during the authentication protocol is executed, and may be re-used for subsequent token requests.  <br/><br/> </dd>
-  <dt>Proof-of-Possession</dt>
-  <dd style="margin-left: 8"><br/> The ACE framework, by default, implements proof-of-possession for access tokens, i.e., that the token holder can prove being a holder of the key bound to the token.  The binding is provided by the "cnf" claim <a href="#I-D.ietf-ace-cwt-proof-of-possession">[I-D.ietf-ace-cwt-proof-of-possession]</a> indicating what key is used for	proof-of-possession. If a client needs to submit a new access token e.g., to obtain additional access rights, they can request that the AS binds this token to the same key as the previous one.  <br/><br/> </dd>
-  <dt>ACE Profiles</dt>
-  <dd style="margin-left: 8"><br/> The client or RS may be limited in the encodings or protocols it supports.  To support a variety of different deployment settings, specific interactions between client and RS are defined in an ACE profile.  In ACE framework the AS is expected to manage the matching of compatible profile choices between a client and an RS.  The AS informs the client of the selected profile using the "profile" parameter in the token response.  </dd>
+<dt>Credential Provisioning</dt>
+<dd style="margin-left: 8">
+<br> For IoT, it cannot be assumed that the client and RS are part of a common key infrastructure, so the AS provisions credentials or associated information to allow mutual authentication. These credentials need to be provided to the parties before or during the authentication protocol is executed, and may be re-used for subsequent token requests.  <br><br> </dd>
+<dt>Proof-of-Possession</dt>
+<dd style="margin-left: 8">
+<br> The ACE framework, by default, implements proof-of-possession for access tokens, i.e., that the token holder can prove being a holder of the key bound to the token.  The binding is provided by the "cnf" claim <a href="#I-D.ietf-ace-cwt-proof-of-possession" class="xref">[I-D.ietf-ace-cwt-proof-of-possession]</a> indicating what key is used for	proof-of-possession. If a client needs to submit a new access token e.g., to obtain additional access rights, they can request that the AS binds this token to the same key as the previous one.  <br><br> </dd>
+<dt>ACE Profiles</dt>
+<dd style="margin-left: 8">
+<br> The client or RS may be limited in the encodings or protocols it supports.  To support a variety of different deployment settings, specific interactions between client and RS are defined in an ACE profile.  In ACE framework the AS is expected to manage the matching of compatible profile choices between a client and an RS.  The AS informs the client of the selected profile using the "profile" parameter in the token response.  </dd>
 </dl>
 
 <p> </p>
 <p id="rfc.section.5.p.3">OAuth 2.0 requires the use of TLS both to protect the communication between AS and client when requesting an access token; between client and RS when accessing a resource and between AS and RS if introspection is used.  In constrained settings TLS is not always feasible, or desirable.  Nevertheless it is REQUIRED that the data exchanged with the AS is encrypted and integrity protected.  It is furthermore REQUIRED that the AS and the endpoint communicating with it (client or RS) perform mutual authentication.</p>
 <p id="rfc.section.5.p.4">Profiles MUST specify how mutual authentication is done, depending e.g.  on the communication protocol and the credentials used by the client or the RS.  </p>
 <p id="rfc.section.5.p.5">In OAuth 2.0 the communication with the Token and the Introspection endpoints at the AS is assumed to be via HTTP and may use Uri-query parameters.  This framework RECOMMENDS to use CoAP instead and RECOMMENDS the use of the following alternative instead of Uri-query parameters: The sender (client or RS) encodes the parameters of its request as a CBOR map and submits that map as the payload  of the POST request.  The Content-format depends on the security applied to the content and MUST be specified by the profile that is used.  </p>
-<p id="rfc.section.5.p.6">The OAuth 2.0 AS uses a JSON structure in the payload of its responses both to client and RS.  This framework REQUIRES the use of CBOR <a href="#RFC7049">[RFC7049]</a> instead.  Depending on the profile, the CBOR payload MAY be enclosed in a non-CBOR cryptographic wrapper.</p>
-<h1 id="rfc.section.5.1"><a href="#rfc.section.5.1">5.1.</a> <a href="#asDiscovery" id="asDiscovery">Discovering Authorization Servers</a></h1>
+<p id="rfc.section.5.p.6">The OAuth 2.0 AS uses a JSON structure in the payload of its responses both to client and RS.  This framework REQUIRES the use of CBOR <a href="#RFC7049" class="xref">[RFC7049]</a> instead.  Depending on the profile, the CBOR payload MAY be enclosed in a non-CBOR cryptographic wrapper.</p>
+<h1 id="rfc.section.5.1">
+<a href="#rfc.section.5.1">5.1.</a> <a href="#asDiscovery" id="asDiscovery">Discovering Authorization Servers</a>
+</h1>
 <p id="rfc.section.5.1.p.1">In order to determine the AS in charge of a resource hosted at the RS, C MAY send an initial Unauthorized Resource Request message to RS.  RS then denies the request and sends the address of its AS back to C.</p>
-<p id="rfc.section.5.1.p.2">Instead of the initial Unauthorized Resource Request message, C MAY look up the desired resource in a resource directory (cf.  <a href="#I-D.ietf-core-resource-directory">[I-D.ietf-core-resource-directory]</a>).</p>
-<h1 id="rfc.section.5.1.1"><a href="#rfc.section.5.1.1">5.1.1.</a> <a href="#rreq" id="rreq">Unauthorized Resource Request Message</a></h1>
+<p id="rfc.section.5.1.p.2">Instead of the initial Unauthorized Resource Request message, C MAY look up the desired resource in a resource directory (cf.  <a href="#I-D.ietf-core-resource-directory" class="xref">[I-D.ietf-core-resource-directory]</a>).</p>
+<h1 id="rfc.section.5.1.1">
+<a href="#rfc.section.5.1.1">5.1.1.</a> <a href="#rreq" id="rreq">Unauthorized Resource Request Message</a>
+</h1>
 <p id="rfc.section.5.1.1.p.1">The optional Unauthorized Resource Request message is a request for a resource hosted by RS for which no proper authorization is granted. RS MUST treat any request for a protected resource as Unauthorized Resource Request message when any of the following holds: </p>
 
 <ul>
-  <li>The request has been received on an unprotected channel.</li>
-  <li>RS has no valid access token for the sender of the request regarding the requested action on that resource.</li>
-  <li>RS has a valid access token for the sender of the request, but this does not allow the requested action on the requested resource.</li>
+<li>The request has been received on an unprotected channel.</li>
+<li>RS has no valid access token for the sender of the request regarding the requested action on that resource.</li>
+<li>RS has a valid access token for the sender of the request, but this does not allow the requested action on the requested resource.</li>
 </ul>
 
 <p> </p>
-<p id="rfc.section.5.1.1.p.2">Note: These conditions ensure that RS can handle requests autonomously once access was granted and a secure channel has been established between C and RS. The authz-info endpoint MUST NOT be protected as specified above, in order to allow clients to upload access tokens to RS (cf.  <a href="#tokenAuthInfoEndpoint">Section 5.8.1</a>).</p>
-<p id="rfc.section.5.1.1.p.3">Unauthorized Resource Request messages MUST be denied with a client error response. In this response, the Resource Server SHOULD provide proper AS Information to enable the Client to request an access token from RS's AS as described in <a href="#asInfo">Section 5.1.2</a>.</p>
+<p id="rfc.section.5.1.1.p.2">Note: These conditions ensure that RS can handle requests autonomously once access was granted and a secure channel has been established between C and RS. The authz-info endpoint MUST NOT be protected as specified above, in order to allow clients to upload access tokens to RS (cf.  <a href="#tokenAuthInfoEndpoint" class="xref">Section 5.8.1</a>).</p>
+<p id="rfc.section.5.1.1.p.3">Unauthorized Resource Request messages MUST be denied with a client error response. In this response, the Resource Server SHOULD provide proper AS Information to enable the Client to request an access token from RS's AS as described in <a href="#asInfo" class="xref">Section 5.1.2</a>.</p>
 <p id="rfc.section.5.1.1.p.4">The response code MUST be 4.01 (Unauthorized) in case the sender of the Unauthorized Resource Request message is not authenticated, or if RS has no valid access token for C. If RS has an access token for C but not for the resource that C has requested, RS MUST reject the request with a 4.03 (Forbidden). If RS has an access token for C but it does not cover the action C requested on the resource, RS MUST reject the request with a 4.05 (Method Not Allowed).</p>
 <p id="rfc.section.5.1.1.p.5">Note: The use of the response codes 4.03 and 4.05 is intended to prevent infinite loops where a dumb Client optimistically tries to access a requested resource with any access token received from AS. As malicious clients could pretend to be C to determine C's privileges, these detailed response codes must be used only when a certain level of security is already available which can be achieved only when the Client is authenticated.</p>
-<h1 id="rfc.section.5.1.2"><a href="#rfc.section.5.1.2">5.1.2.</a> <a href="#asInfo" id="asInfo">AS Information</a></h1>
-<p id="rfc.section.5.1.2.p.1">The AS Information is sent by RS as a response to an Unauthorized Resource Request message (see <a href="#rreq">Section 5.1.1</a>) to point the sender of the Unauthorized Resource Request message to RS&#8217;s AS. The AS information is a set of attributes containing an absolute URI (see Section 4.3 of <a href="#RFC3986">[RFC3986]</a>) that specifies the AS in charge of RS.</p>
+<h1 id="rfc.section.5.1.2">
+<a href="#rfc.section.5.1.2">5.1.2.</a> <a href="#asInfo" id="asInfo">AS Information</a>
+</h1>
+<p id="rfc.section.5.1.2.p.1">The AS Information is sent by RS as a response to an Unauthorized Resource Request message (see <a href="#rreq" class="xref">Section 5.1.1</a>) to point the sender of the Unauthorized Resource Request message to RS&#8217;s AS. The AS information is a set of attributes containing an absolute URI (see Section 4.3 of <a href="#RFC3986" class="xref">[RFC3986]</a>) that specifies the AS in charge of RS.</p>
 <p id="rfc.section.5.1.2.p.2">The message MAY also contain a nonce generated by RS to ensure freshness in case that the RS and AS do not have synchronized clocks.</p>
-<div id="rfc.figure.2"/>
-<div id="fig:asinfo"/>
+<div id="rfc.figure.2"></div>
+<div id="fig:asinfo"></div>
 <pre>
         /-------+----------+-------------\
         | Name  | CBOR Key | Value Type  |
@@ -776,10 +897,10 @@
         \-------+----------+-------------/
       </pre>
 <p class="figure">Figure 2: AS Information parameters</p>
-<p><a href="#fig:asinfo">Figure 2</a> summarizes the parameters that may be part of the AS Information.  </p>
-<p><a href="#fig:as-info-payload">Figure 3</a> shows an example for an AS Information message payload using CBOR <a href="#RFC7049">[RFC7049]</a> diagnostic notation, using the parameter names instead of the CBOR keys for better human readability.</p>
-<div id="rfc.figure.3"/>
-<div id="fig:as-info-payload"/>
+<p><a href="#fig:asinfo" class="xref">Figure 2</a> summarizes the parameters that may be part of the AS Information.  </p>
+<p><a href="#fig:as-info-payload" class="xref">Figure 3</a> shows an example for an AS Information message payload using CBOR <a href="#RFC7049" class="xref">[RFC7049]</a> diagnostic notation, using the parameter names instead of the CBOR keys for better human readability.</p>
+<div id="rfc.figure.3"></div>
+<div id="fig:as-info-payload"></div>
 <pre>
     4.01 Unauthorized
     Content-Format: application/ace+cbor
@@ -788,15 +909,15 @@
 </pre>
 <p class="figure">Figure 3: AS Information payload example</p>
 <p id="rfc.section.5.1.2.p.5">In this example, the attribute AS points the receiver of this message to the URI &#8220;coaps://as.example.com/token&#8221; to request access permissions.  The originator of the AS Information payload (i.e., RS) uses a local clock that is loosely synchronized with a time scale common between RS and AS (e.g., wall clock time). Therefore, it has included a parameter <samp>nonce</samp> for replay attack prevention.</p>
-<p/>
+<p></p>
 
 <dl>
-  <dt>Note: There is an ongoing discussion how freshness of      access tokens</dt>
-  <dd style="margin-left: 8">can be achieved in constrained environments. This specification for now assumes that RS and AS do not have a common understanding of time that allows RS to achieve its security objectives without explicitly adding a nonce.</dd>
+<dt>Note: There is an ongoing discussion how freshness of      access tokens</dt>
+<dd style="margin-left: 8">can be achieved in constrained environments. This specification for now assumes that RS and AS do not have a common understanding of time that allows RS to achieve its security objectives without explicitly adding a nonce.</dd>
 </dl>
-<p><a href="#fig:as-info-cbor">Figure 4</a> illustrates the mandatory to use binary encoding of the message payload shown in <a href="#fig:as-info-payload">Figure 3</a>.</p>
-<div id="rfc.figure.4"/>
-<div id="fig:as-info-cbor"/>
+<p><a href="#fig:as-info-cbor" class="xref">Figure 4</a> illustrates the mandatory to use binary encoding of the message payload shown in <a href="#fig:as-info-payload" class="xref">Figure 3</a>.</p>
+<div id="rfc.figure.4"></div>
+<div id="fig:as-info-cbor"></div>
 <pre>
 a2                                   # map(2)
     00                               # unsigned(0) (=AS)
@@ -808,41 +929,57 @@ a2                                   # map(2)
        e0a156bb3f
 </pre>
 <p class="figure">Figure 4: AS Information example encoded in CBOR</p>
-<h1 id="rfc.section.5.2"><a href="#rfc.section.5.2">5.2.</a> <a href="#authorizationGrants" id="authorizationGrants">Authorization Grants</a></h1>
+<h1 id="rfc.section.5.2">
+<a href="#rfc.section.5.2">5.2.</a> <a href="#authorizationGrants" id="authorizationGrants">Authorization Grants</a>
+</h1>
 <p id="rfc.section.5.2.p.1">To request an access token, the client obtains authorization from the resource owner or uses its client credentials as grant.  The authorization is expressed in the form of an authorization grant.</p>
 <p id="rfc.section.5.2.p.2">The OAuth framework defines four grant types. The grant types can be split up into two groups, those granted on behalf of the resource owner (password, authorization code, implicit) and those for the client (client credentials).</p>
-<p id="rfc.section.5.2.p.3">The grant type is selected depending on the use case.  In cases where the client acts on behalf of the resource owner, authorization code grant is recommended.  If the client acts on behalf of the resource owner, but does not have any display or very limited interaction possibilities it is recommended to use the device code grant defined in <a href="#I-D.ietf-oauth-device-flow">[I-D.ietf-oauth-device-flow]</a>.  In cases where the client does not act on behalf of the resource owner, client credentials grant is recommended.</p>
-<p id="rfc.section.5.2.p.4">For details on the different grant types, see the OAuth 2.0 framework <a href="#RFC6749">[RFC6749]</a>. The OAuth 2.0 framework provides an extension mechanism for defining additional grant types so profiles of this framework MAY define additional grant types, if needed.</p>
-<h1 id="rfc.section.5.3"><a href="#rfc.section.5.3">5.3.</a> <a href="#clientCredentials" id="clientCredentials">Client Credentials</a></h1>
+<p id="rfc.section.5.2.p.3">The grant type is selected depending on the use case.  In cases where the client acts on behalf of the resource owner, authorization code grant is recommended.  If the client acts on behalf of the resource owner, but does not have any display or very limited interaction possibilities it is recommended to use the device code grant defined in <a href="#I-D.ietf-oauth-device-flow" class="xref">[I-D.ietf-oauth-device-flow]</a>.  In cases where the client does not act on behalf of the resource owner, client credentials grant is recommended.</p>
+<p id="rfc.section.5.2.p.4">For details on the different grant types, see the OAuth 2.0 framework <a href="#RFC6749" class="xref">[RFC6749]</a>. The OAuth 2.0 framework provides an extension mechanism for defining additional grant types so profiles of this framework MAY define additional grant types, if needed.</p>
+<h1 id="rfc.section.5.3">
+<a href="#rfc.section.5.3">5.3.</a> <a href="#clientCredentials" id="clientCredentials">Client Credentials</a>
+</h1>
 <p id="rfc.section.5.3.p.1">Authentication of the client is mandatory independent of the grant type when requesting the access token from the token endpoint. In the case of client credentials grant type, the authentication and grant coincide.</p>
 <p id="rfc.section.5.3.p.2">Client registration and provisioning of client credentials to the client is out of scope for this specification.</p>
-<p id="rfc.section.5.3.p.3">The OAuth framework <a href="#RFC6749">[RFC6749]</a> defines one client credential type, client id and client secret. <a href="#I-D.erdtman-ace-rpcc">[I-D.erdtman-ace-rpcc]</a> adds raw-public-key and pre-shared-key to the client credentials types.  Profiles of this framework MAY extend with additional client credentials client certificates.</p>
-<h1 id="rfc.section.5.4"><a href="#rfc.section.5.4">5.4.</a> <a href="#ASAuthentication" id="ASAuthentication">AS Authentication</a></h1>
+<p id="rfc.section.5.3.p.3">The OAuth framework <a href="#RFC6749" class="xref">[RFC6749]</a> defines one client credential type, client id and client secret. <a href="#I-D.erdtman-ace-rpcc" class="xref">[I-D.erdtman-ace-rpcc]</a> adds raw-public-key and pre-shared-key to the client credentials types.  Profiles of this framework MAY extend with additional client credentials client certificates.</p>
+<h1 id="rfc.section.5.4">
+<a href="#rfc.section.5.4">5.4.</a> <a href="#ASAuthentication" id="ASAuthentication">AS Authentication</a>
+</h1>
 <p id="rfc.section.5.4.p.1">Client credential does not, by default, authenticate the AS that the client connects to. In classic OAuth, the AS is authenticated with a TLS server certificate.</p>
 <p id="rfc.section.5.4.p.2">Profiles of this framework MUST specify how clients authenticate the AS and how communication security is implemented, otherwise server side TLS certificates, as defined by OAuth 2.0, are required.</p>
-<h1 id="rfc.section.5.5"><a href="#rfc.section.5.5">5.5.</a> <a href="#authorizeEndpoint" id="authorizeEndpoint">The Authorization Endpoint</a></h1>
-<p id="rfc.section.5.5.p.1">The authorization endpoint is used to interact with the resource owner and obtain an authorization grant in certain grant flows.  Since it requires the use of a user agent (i.e., browser), it is not expected that these types of grant flow will be used by constrained clients.  This endpoint is therefore out of scope for this specification.  Implementations should use the definition and recommendations of <a href="#RFC6749">[RFC6749]</a> and <a href="#RFC6819">[RFC6819]</a>.</p>
+<h1 id="rfc.section.5.5">
+<a href="#rfc.section.5.5">5.5.</a> <a href="#authorizeEndpoint" id="authorizeEndpoint">The Authorization Endpoint</a>
+</h1>
+<p id="rfc.section.5.5.p.1">The authorization endpoint is used to interact with the resource owner and obtain an authorization grant in certain grant flows.  Since it requires the use of a user agent (i.e., browser), it is not expected that these types of grant flow will be used by constrained clients.  This endpoint is therefore out of scope for this specification.  Implementations should use the definition and recommendations of <a href="#RFC6749" class="xref">[RFC6749]</a> and <a href="#RFC6819" class="xref">[RFC6819]</a>.</p>
 <p id="rfc.section.5.5.p.2">If clients involved cannot support HTTP and TLS, profiles MAY define mappings for the authorization endpoint.</p>
-<h1 id="rfc.section.5.6"><a href="#rfc.section.5.6">5.6.</a> <a href="#tokenEndpoint" id="tokenEndpoint">The Token Endpoint</a></h1>
+<h1 id="rfc.section.5.6">
+<a href="#rfc.section.5.6">5.6.</a> <a href="#tokenEndpoint" id="tokenEndpoint">The Token Endpoint</a>
+</h1>
 <p id="rfc.section.5.6.p.1">In standard OAuth 2.0, the AS provides the token endpoint for submitting access token requests.  This framework extends the functionality of the token endpoint, giving the AS the possibility to help the client and RS to establish shared keys or to exchange their public keys.  Furthermore, this framework defines encodings using CBOR, as a substitute for JSON.</p>
-<p id="rfc.section.5.6.p.2">For the AS to be able to issue a token, the client MUST be authenticated and present a valid grant for the scopes requested.  Profiles of this framework MUST specify how the AS authenticates the client and how the communication between client and AS is protected.</p>
-<p id="rfc.section.5.6.p.3">The default name of this endpoint in an url-path is 'token', however implementations are not required to use this name and can define their own instead.</p>
-<p id="rfc.section.5.6.p.4">The figures of this section use CBOR diagnostic notation without the integer abbreviations for the parameters or their values for illustrative purposes. Note that implementations MUST use the integer abbreviations and the binary CBOR encoding.</p>
-<h1 id="rfc.section.5.6.1"><a href="#rfc.section.5.6.1">5.6.1.</a> <a href="#tokenRequest" id="tokenRequest">Client-to-AS Request</a></h1>
-<p id="rfc.section.5.6.1.p.1">The client sends a POST request to the token endpoint at the AS. The profile MUST specify the Content-Type and wrapping of the payload.  The content of the request consists of the parameters specified in section 4 of the OAuth 2.0 specification <a href="#RFC6749">[RFC6749]</a>, encoded as a CBOR map, where the "scope" parameter can additionally be formatted as a byte array, in order to allow compact encoding of complex scope structures.</p>
+<p id="rfc.section.5.6.p.2">The endpoint may, however, be exposed over HTTPS as in classical OAuth or even other transports.  A profile MUST define the details of the mapping between the fields described below, and these transports.  If HTTPS is used, JSON or CBOR payloads may be supported. If JSON payloads are used, the semantics of Section 4 of the OAuth 2.0 specification MUST be followed (with additions as described below). If CBOR payload is supported, the semantics described below MUST be followed.</p>
+<p id="rfc.section.5.6.p.3">For the AS to be able to issue a token, the client MUST be authenticated and present a valid grant for the scopes requested.  Profiles of this framework MUST specify how the AS authenticates the client and how the communication between client and AS is protected.</p>
+<p id="rfc.section.5.6.p.4">The default name of this endpoint in an url-path is 'token', however implementations are not required to use this name and can define their own instead.</p>
+<p id="rfc.section.5.6.p.5">The figures of this section use CBOR diagnostic notation without the integer abbreviations for the parameters or their values for illustrative purposes. Note that implementations MUST use the integer abbreviations and the binary CBOR encoding, if the CBOR encoding is used.</p>
+<h1 id="rfc.section.5.6.1">
+<a href="#rfc.section.5.6.1">5.6.1.</a> <a href="#tokenRequest" id="tokenRequest">Client-to-AS Request</a>
+</h1>
+<p id="rfc.section.5.6.1.p.1">The client sends a POST request to the token endpoint at the AS. The profile MUST specify the Content-Type and wrapping of the payload.  The content of the request consists of the parameters specified in Section 4 of the OAuth 2.0 specification <a href="#RFC6749" class="xref">[RFC6749]</a>, encoded as a CBOR map (if a CBOR encoding is used), where the "scope" parameter can additionally be formatted as a byte array, in order to allow compact encoding of complex scope structures.</p>
 <p id="rfc.section.5.6.1.p.2">In addition to these parameters, this framework defines the following parameters for requesting an access token from a token endpoint: </p>
 
 <dl>
-  <dt>aud</dt>
-  <dd style="margin-left: 8"><br/> OPTIONAL.  Specifies the audience for which the client is requesting an access token.  If this parameter is missing, it is assumed that the client and the AS have a pre-established understanding of the audience that an access token should address.  If a client submits a request for an access token without specifying an "aud" parameter, and the AS does not have an implicit understanding of the "aud" value for this client, then the AS MUST respond with an error message	using a response code equivalent to the CoAP response code 4.00 (Bad Request).  <br/><br/></dd>
-  <dt>cnf</dt>
-  <dd style="margin-left: 8"><br/> OPTIONAL.  This field contains information about the key the client would like to bind to the access token for proof-of-possession.  It is RECOMMENDED that an AS reject a request containing a symmetric key value in the 'cnf' field, since the AS is expected to be able to generate better symmetric keys than a potentially constrained client.  See <a href="#paramCnf">Section 5.6.4.5</a> for more details on the formatting of the 'cnf' parameter.</dd>
+<dt>aud</dt>
+<dd style="margin-left: 8">
+<br> OPTIONAL.  Specifies the audience for which the client is requesting an access token.  If this parameter is missing, it is assumed that the client and the AS have a pre-established understanding of the audience that an access token should address.  If a client submits a request for an access token without specifying an "aud" parameter, and the AS does not have an implicit understanding of the "aud" value for this client, then the AS MUST respond with an error message	using a response code equivalent to the CoAP response code 4.00 (Bad Request).  <br><br>
+</dd>
+<dt>cnf</dt>
+<dd style="margin-left: 8">
+<br> OPTIONAL.  This field contains information about the key the client would like to bind to the access token for proof-of-possession.  It is RECOMMENDED that an AS reject a request containing a symmetric key value in the 'cnf' field, since the AS is expected to be able to generate better symmetric keys than a potentially constrained client.  See <a href="#paramCnf" class="xref">Section 5.6.4.5</a> for more details on the formatting of the 'cnf' parameter.</dd>
 </dl>
 
 <p> </p>
 <p id="rfc.section.5.6.1.p.3">The following examples illustrate different types of requests for proof-of-possession tokens. </p>
-<div id="rfc.figure.5"/>
-<div id="fig:symmATreq"/>
+<div id="rfc.figure.5"></div>
+<div id="fig:symmATreq"></div>
 <pre>
 Header: POST (Code=0.02)
 Uri-Host: "as.example.com"
@@ -856,9 +993,9 @@ Payload:
  }
         </pre>
 <p class="figure">Figure 5: Example request for an access token bound to a      symmetric key.</p>
-<p><a href="#fig:symmATreq">Figure 5</a> shows a request for a token with a symmetric proof-of-possession key.  Note that in this example it is assumed that transport layer communication security is used, therefore the Content-Type is "application/cbor".  The content is displayed in CBOR diagnostic notation, without abbreviations for better readability.  </p>
-<div id="rfc.figure.6"/>
-<div id="fig:asymmATreq"/>
+<p><a href="#fig:symmATreq" class="xref">Figure 5</a> shows a request for a token with a symmetric proof-of-possession key.  Note that in this example it is assumed that transport layer communication security is used with a CBOR payload, therefore the Content-Type is "application/cbor".  The content is displayed in CBOR diagnostic notation, without abbreviations for better readability.  </p>
+<div id="rfc.figure.6"></div>
+<div id="fig:asymmATreq"></div>
 <pre>
 Header: POST (Code=0.02)
 Uri-Host: "as.example.com"
@@ -889,9 +1026,9 @@ Decrypted payload:
 }
         </pre>
 <p class="figure">Figure 6: Example token request bound to an asymmetric key.</p>
-<p><a href="#fig:asymmATreq">Figure 6</a> shows a request for a token with an asymmetric proof-of-possession key.  Note that in this example COSE is used to provide object-security, therefore the Content-Type is "application/cose".  </p>
-<div id="rfc.figure.7"/>
-<div id="fig:kidATreq"/>
+<p><a href="#fig:asymmATreq" class="xref">Figure 6</a> shows a request for a token with an asymmetric proof-of-possession key.  Note that in this example COSE is used to provide object-security, therefore the Content-Type is "application/cose".  </p>
+<div id="rfc.figure.7"></div>
+<div id="fig:kidATreq"></div>
 <pre>
 Header: POST (Code=0.02)
 Uri-Host: "as.example.com"
@@ -910,27 +1047,29 @@ Payload:
 }
        </pre>
 <p class="figure">Figure 7: Example request for an access token bound to a      key reference.</p>
-<p><a href="#fig:kidATreq">Figure 7</a> shows a request for a token where a previously communicated proof-of-possession key is only referenced.  Note that a transport layer based communication security profile is assumed in this example, therefore the Content-Type is "application/cbor".  Also note that the client performs a password based authentication in this example by submitting its client_secret (see section 2.3.1. of <a href="#RFC6749">[RFC6749]</a>).  </p>
-<h1 id="rfc.section.5.6.2"><a href="#rfc.section.5.6.2">5.6.2.</a> <a href="#tokenResponse" id="tokenResponse">AS-to-Client Response</a></h1>
-<p id="rfc.section.5.6.2.p.1">If the access token request has been successfully verified by the AS and the client is authorized to obtain an access token corresponding to its access token request, the AS sends a response with the response code equivalent to the CoAP response code 2.01 (Created).  If client request was invalid, or not authorized, the AS returns an error response as described in <a href="#errorsToken">Section 5.6.3</a>.</p>
-<p id="rfc.section.5.6.2.p.2">Note that the AS decides which token type and profile to use when issuing a successful response.  It is assumed that the AS has prior knowledge of the capabilities of the client and the RS (see <a href="#app:registration">Appendix D</a>.  This prior knowledge may, for example, be set by the use of a dynamic client registration protocol exchange <a href="#RFC7591">[RFC7591]</a>.</p>
-<p id="rfc.section.5.6.2.p.3">The content of the successful reply is the RS Information. It MUST be encoded as CBOR map, containing parameters as specified in section 5.1 of <a href="#RFC6749">[RFC6749]</a>.  In addition to these parameters, the following parameters are also part of a successful response: </p>
+<p><a href="#fig:kidATreq" class="xref">Figure 7</a> shows a request for a token where a previously communicated proof-of-possession key is only referenced.  Note that a transport layer based communication security profile with a CBOR payload is assumed in this example, therefore the Content-Type is "application/cbor".  Also note that the client performs a password based authentication in this example by submitting its client_secret (see Section 2.3.1 of <a href="#RFC6749" class="xref">[RFC6749]</a>).  </p>
+<h1 id="rfc.section.5.6.2">
+<a href="#rfc.section.5.6.2">5.6.2.</a> <a href="#tokenResponse" id="tokenResponse">AS-to-Client Response</a>
+</h1>
+<p id="rfc.section.5.6.2.p.1">If the access token request has been successfully verified by the AS and the client is authorized to obtain an access token corresponding to its access token request, the AS sends a response with the response code equivalent to the CoAP response code 2.01 (Created).  If client request was invalid, or not authorized, the AS returns an error response as described in <a href="#errorsToken" class="xref">Section 5.6.3</a>.</p>
+<p id="rfc.section.5.6.2.p.2">Note that the AS decides which token type and profile to use when issuing a successful response.  It is assumed that the AS has prior knowledge of the capabilities of the client and the RS (see <a href="#app:registration" class="xref">Appendix D</a>.  This prior knowledge may, for example, be set by the use of a dynamic client registration protocol exchange <a href="#RFC7591" class="xref">[RFC7591]</a>.</p>
+<p id="rfc.section.5.6.2.p.3">The content of the successful reply is the RS Information.  When using CBOR payloads, the content MUST be encoded as CBOR map, containing parameters as specified in Section 5.1 of <a href="#RFC6749" class="xref">[RFC6749]</a>.  In addition to these parameters, the following parameters are also part of a successful response: </p>
 
 <dl>
-  <dt>profile</dt>
-  <dd style="margin-left: 8">OPTIONAL.  This indicates the profile that the client MUST use towards the RS. See <a href="#paramProfile">Section 5.6.4.4</a> for the formatting of this parameter.<br/><br/>. If this parameter is absent, the AS assumes that the client implicitly knows which profile to use towards the RS.</dd>
-  <dt>cnf</dt>
-  <dd style="margin-left: 8">REQUIRED if the token type is "pop" and a symmetric key is used.  MUST NOT be present otherwise. This field contains the symmetric proof-of-possession key the client is supposed to use.  See <a href="#paramCnf">Section 5.6.4.5</a> for details on the use of this parameter.</dd>
-  <dt>rs_cnf</dt>
-  <dd style="margin-left: 8">OPTIONAL if the token type is "pop" and asymmetric keys are used.  MUST NOT be present otherwise. This field contains information about the public key used by the RS to authenticate.  See <a href="#paramCnf">Section 5.6.4.5</a> for details on the use of this parameter. If this parameter is absent, the AS assumes that the client already knows the public key of the RS.</dd>
-  <dt>token_type</dt>
-  <dd style="margin-left: 8">OPTIONAL.  By default implementations of this framework SHOULD assume that the token_type is "pop".  If a specific use case requires another token_type (e.g., "Bearer") to be used then this parameter is REQUIRED.  </dd>
+<dt>profile</dt>
+<dd style="margin-left: 8">OPTIONAL.  This indicates the profile that the client MUST use towards the RS. See <a href="#paramProfile" class="xref">Section 5.6.4.4</a> for the formatting of this parameter.<br><br>. If this parameter is absent, the AS assumes that the client implicitly knows which profile to use towards the RS.</dd>
+<dt>cnf</dt>
+<dd style="margin-left: 8">REQUIRED if the token type is "pop" and a symmetric key is used.  MUST NOT be present otherwise. This field contains the symmetric proof-of-possession key the client is supposed to use.  See <a href="#paramCnf" class="xref">Section 5.6.4.5</a> for details on the use of this parameter.</dd>
+<dt>rs_cnf</dt>
+<dd style="margin-left: 8">OPTIONAL if the token type is "pop" and asymmetric keys are used.  MUST NOT be present otherwise. This field contains information about the public key used by the RS to authenticate.  See <a href="#paramCnf" class="xref">Section 5.6.4.5</a> for details on the use of this parameter. If this parameter is absent, the AS assumes that the client already knows the public key of the RS.</dd>
+<dt>token_type</dt>
+<dd style="margin-left: 8">OPTIONAL.  By default implementations of this framework SHOULD assume that the token_type is "pop".  If a specific use case requires another token_type (e.g., "Bearer") to be used then this parameter is REQUIRED.  </dd>
 </dl>
 
 <p> </p>
-<p id="rfc.section.5.6.2.p.4">Note that if CBOR Web Tokens <a href="#I-D.ietf-ace-cbor-web-token">[I-D.ietf-ace-cbor-web-token]</a> are used, the access token can also contain a "cnf" claim <a href="#I-D.ietf-ace-cwt-proof-of-possession">[I-D.ietf-ace-cwt-proof-of-possession]</a>.  This claim is however consumed by a different party.  The access token is created by the AS and processed by the RS (and opaque to the client) whereas the RS Information is created by the AS and processed by the client; it is never forwarded to the resource server.</p>
-<div id="rfc.figure.8"/>
-<div id="fig:rsinfo"/>
+<p id="rfc.section.5.6.2.p.4">Note that if CBOR Web Tokens <a href="#I-D.ietf-ace-cbor-web-token" class="xref">[I-D.ietf-ace-cbor-web-token]</a> are used, the access token can also contain a "cnf" claim <a href="#I-D.ietf-ace-cwt-proof-of-possession" class="xref">[I-D.ietf-ace-cwt-proof-of-possession]</a>.  This claim is however consumed by a different party.  The access token is created by the AS and processed by the RS (and opaque to the client) whereas the RS Information is created by the AS and processed by the client; it is never forwarded to the resource server.</p>
+<div id="rfc.figure.8"></div>
+<div id="fig:rsinfo"></div>
 <pre>
         /-------------------+-----------------\
         | Parameter name    | Specified in    |
@@ -950,9 +1089,9 @@ Payload:
         \-------------------+-----------------/
       </pre>
 <p class="figure">Figure 8: RS Information parameters</p>
-<p><a href="#fig:rsinfo">Figure 8</a> summarizes the parameters that may be part of the RS Information.  </p>
-<div id="rfc.figure.9"/>
-<div id="fig:symmATres"/>
+<p><a href="#fig:rsinfo" class="xref">Figure 8</a> summarizes the parameters that may be part of the RS Information.  </p>
+<div id="rfc.figure.9"></div>
+<div id="fig:symmATres"></div>
 <pre>
 Header: Created (Code=2.01)
 Content-Type: "application/cbor"
@@ -973,10 +1112,12 @@ Payload:
 }
       </pre>
 <p class="figure">Figure 9: Example AS response with an access token bound to a      symmetric key.</p>
-<p><a href="#fig:symmATres">Figure 9</a> shows a response containing a token and a "cnf" parameter with a symmetric proof-of-possession key.  Note that transport layer security is assumed in this example, therefore the Content-Type is "application/cbor".  </p>
-<h1 id="rfc.section.5.6.3"><a href="#rfc.section.5.6.3">5.6.3.</a> <a href="#errorsToken" id="errorsToken">Error Response</a></h1>
-<div id="rfc.figure.10"/>
-<div id="fig:cborErrorCodes"/>
+<p><a href="#fig:symmATres" class="xref">Figure 9</a> shows a response containing a token and a "cnf" parameter with a symmetric proof-of-possession key.  Note that transport layer security with CBOR encoding is assumed in this example, therefore the Content-Type is "application/cbor".  </p>
+<h1 id="rfc.section.5.6.3">
+<a href="#rfc.section.5.6.3">5.6.3.</a> <a href="#errorsToken" id="errorsToken">Error Response</a>
+</h1>
+<div id="rfc.figure.10"></div>
+<div id="fig:cborErrorCodes"></div>
 <pre>
         /------------------------+----------\
         | Name                   | CBOR Key |
@@ -991,24 +1132,30 @@ Payload:
         \------------------------+----------/
         </pre>
 <p class="figure">Figure 10: CBOR abbreviations for common error codes</p>
-<p id="rfc.section.5.6.3.p.1">The error responses for CoAP-based interactions with the AS are equivalent to the ones for HTTP-based interactions as defined in section 5.2 of <a href="#RFC6749">[RFC6749]</a>, with the following differences: </p>
+<p id="rfc.section.5.6.3.p.1">The error responses for CoAP-based interactions with the AS are equivalent to the ones for HTTP-based interactions as defined in Section 5.2 of <a href="#RFC6749" class="xref">[RFC6749]</a>, with the following differences: </p>
 
 <ul>
-  <li>The Content-Type MUST be specified by the communication security profile used between client and AS.  The raw payload before being processed by the communication security protocol MUST be encoded as a CBOR map.</li>
-  <li>A response code equivalent to the CoAP code 4.00 (Bad Request) MUST be used for all error responses, except for invalid_client where a response code equivalent to the CoAP code 4.01 (Unauthorized) MAY be used under the same conditions as specified in section 5.2 of <a href="#RFC6749">[RFC6749]</a>.  </li>
-  <li>The parameters "error", "error_description" and "error_uri" MUST be abbreviated using the codes specified in <a href="#fig:cborTokenParameters">Figure 12</a>.</li>
-  <li>The error code (i.e., value of the "error" parameter) MUST be abbreviated as specified in <a href="#fig:cborErrorCodes">Figure 10</a>.</li>
+<li>The Content-Type MUST be specified by the communication security profile used between client and AS.  The raw payload before being processed by the communication security protocol MUST be encoded as a CBOR map.</li>
+<li>A response code equivalent to the CoAP code 4.00 (Bad Request) MUST be used for all error responses, except for invalid_client where a response code equivalent to the CoAP code 4.01 (Unauthorized) MAY be used under the same conditions as specified in Section 5.2 of <a href="#RFC6749" class="xref">[RFC6749]</a>.  </li>
+<li>The parameters "error", "error_description" and "error_uri" MUST be abbreviated using the codes specified in <a href="#fig:cborTokenParameters" class="xref">Figure 12</a>, when a CBOR encoding is used.</li>
+<li>The error code (i.e., value of the "error" parameter) MUST be abbreviated as specified in <a href="#fig:cborErrorCodes" class="xref">Figure 10</a>, when a CBOR encoding is used.</li>
 </ul>
 
 <p> </p>
-<p id="rfc.section.5.6.3.p.2">In addition to the error responses defined in OAuth 2.0, the following behavior MUST be implemented by the AS: If the client submits an asymmetric key in the token request that the RS cannot process, the AS MUST reject that request with a response code equivalent to the CoAP code 4.00 (Bad Request) including the error code "unsupported_pop_key" defined in <a href="#fig:cborErrorCodes">Figure 10</a>.</p>
-<h1 id="rfc.section.5.6.4"><a href="#rfc.section.5.6.4">5.6.4.</a> <a href="#tokenParams" id="tokenParams">Request and Response Parameters</a></h1>
+<p id="rfc.section.5.6.3.p.2">In addition to the error responses defined in OAuth 2.0, the following behavior MUST be implemented by the AS: If the client submits an asymmetric key in the token request that the RS cannot process, the AS MUST reject that request with a response code equivalent to the CoAP code 4.00 (Bad Request) including the error code "unsupported_pop_key" defined in <a href="#fig:cborErrorCodes" class="xref">Figure 10</a>.</p>
+<h1 id="rfc.section.5.6.4">
+<a href="#rfc.section.5.6.4">5.6.4.</a> <a href="#tokenParams" id="tokenParams">Request and Response Parameters</a>
+</h1>
 <p id="rfc.section.5.6.4.p.1">This section provides more detail about the new parameters that can be used in access token requests and responses, as well as abbreviations for more compact encoding of existing parameters and common parameter values.</p>
-<h1 id="rfc.section.5.6.4.1"><a href="#rfc.section.5.6.4.1">5.6.4.1.</a> <a href="#paramAud" id="paramAud">Audience</a></h1>
-<p id="rfc.section.5.6.4.1.p.1">This parameter specifies for which audience the client is requesting a token.  It should be encoded as CBOR text string.  The formatting and semantics of these strings are application specific.</p>
-<h1 id="rfc.section.5.6.4.2"><a href="#rfc.section.5.6.4.2">5.6.4.2.</a> <a href="#paramGrantType" id="paramGrantType">Grant Type</a></h1>
-<div id="rfc.figure.11"/>
-<div id="fig:grant_types"/>
+<h1 id="rfc.section.5.6.4.1">
+<a href="#rfc.section.5.6.4.1">5.6.4.1.</a> <a href="#paramAud" id="paramAud">Audience</a>
+</h1>
+<p id="rfc.section.5.6.4.1.p.1">This parameter specifies for which audience the client is requesting a token. If using CBOR payload it should be encoded as CBOR text string.  The formatting and semantics of these strings are application specific.</p>
+<h1 id="rfc.section.5.6.4.2">
+<a href="#rfc.section.5.6.4.2">5.6.4.2.</a> <a href="#paramGrantType" id="paramGrantType">Grant Type</a>
+</h1>
+<div id="rfc.figure.11"></div>
+<div id="fig:grant_types"></div>
 <pre>
         /--------------------+----------+------------------------\
         | Name               | CBOR Key | Original Specification |
@@ -1020,32 +1167,40 @@ Payload:
         \--------------------+----------+------------------------/
         </pre>
 <p class="figure">Figure 11: CBOR abbreviations for common grant types </p>
-<p id="rfc.section.5.6.4.2.p.1">The abbreviations in <a href="#fig:grant_types">Figure 11</a> MUST be used in CBOR encodings instead of the string values defined in <a href="#RFC6749">[RFC6749]</a>.  </p>
-<h1 id="rfc.section.5.6.4.3"><a href="#rfc.section.5.6.4.3">5.6.4.3.</a> <a href="#paramTokenType" id="paramTokenType">Token Type</a></h1>
-<p id="rfc.section.5.6.4.3.p.1">The token_type parameter is defined in <a href="#RFC6749">[RFC6749]</a>, allowing the AS to indicate to the client which type of access token it is receiving (e.g., a bearer token). </p>
+<p id="rfc.section.5.6.4.2.p.1">The abbreviations in <a href="#fig:grant_types" class="xref">Figure 11</a> MUST be used in CBOR encodings instead of the string values defined in <a href="#RFC6749" class="xref">[RFC6749]</a>, if CBOR payloads are used.  </p>
+<h1 id="rfc.section.5.6.4.3">
+<a href="#rfc.section.5.6.4.3">5.6.4.3.</a> <a href="#paramTokenType" id="paramTokenType">Token Type</a>
+</h1>
+<p id="rfc.section.5.6.4.3.p.1">The token_type parameter is defined in <a href="#RFC6749" class="xref">[RFC6749]</a>, allowing the AS to indicate to the client which type of access token it is receiving (e.g., a bearer token). </p>
 <p id="rfc.section.5.6.4.3.p.2">This document registers the new value "pop" for the OAuth Access Token Types registry,  specifying a Proof-of-Possession token.  How the proof-of-possession is performed MUST be specified by the profiles.</p>
-<p id="rfc.section.5.6.4.3.p.3">The values in the "token_type" parameter MUST be CBOR text strings.</p>
+<p id="rfc.section.5.6.4.3.p.3">The values in the "token_type" parameter MUST be CBOR text strings, if a CBOR encoding is used. </p>
 <p id="rfc.section.5.6.4.3.p.4">In this framework token type "pop" MUST be assumed by default if the AS does not provide a different value.</p>
-<h1 id="rfc.section.5.6.4.4"><a href="#rfc.section.5.6.4.4">5.6.4.4.</a> <a href="#paramProfile" id="paramProfile">Profile</a></h1>
+<h1 id="rfc.section.5.6.4.4">
+<a href="#rfc.section.5.6.4.4">5.6.4.4.</a> <a href="#paramProfile" id="paramProfile">Profile</a>
+</h1>
 <p id="rfc.section.5.6.4.4.p.1">Profiles of this framework MUST define the communication protocol and the communication security protocol between the client and the RS.  The security protocol MUST provide encryption, integrity and replay protection.  Furthermore profiles MUST define proof-of-possession methods, if they support proof-of-possession tokens.</p>
 <p id="rfc.section.5.6.4.4.p.2">A profile MUST specify an identifier that can be used to uniquely identify itself in the "profile" parameter.</p>
 <p id="rfc.section.5.6.4.4.p.3">Profiles MAY define additional parameters for both the token request and the RS Information in the access token response in order to support negotiation or signaling of profile specific parameters.  </p>
-<h1 id="rfc.section.5.6.4.5"><a href="#rfc.section.5.6.4.5">5.6.4.5.</a> <a href="#paramCnf" id="paramCnf">Confirmation</a></h1>
-<p id="rfc.section.5.6.4.5.p.1">The "cnf" parameter identifies or provides the key used for proof-of-possession, while the "rs_cnf" parameter provides the raw public key of the RS.  Both parameters use the same formatting and semantics as the "cnf" claim specified in <a href="#I-D.ietf-ace-cwt-proof-of-possession">[I-D.ietf-ace-cwt-proof-of-possession]</a>.</p>
+<h1 id="rfc.section.5.6.4.5">
+<a href="#rfc.section.5.6.4.5">5.6.4.5.</a> <a href="#paramCnf" id="paramCnf">Confirmation</a>
+</h1>
+<p id="rfc.section.5.6.4.5.p.1">The "cnf" parameter identifies or provides the key used for proof-of-possession, while the "rs_cnf" parameter provides the raw public key of the RS.  Both parameters use the same formatting and semantics as the "cnf" claim specified in <a href="#I-D.ietf-ace-cwt-proof-of-possession" class="xref">[I-D.ietf-ace-cwt-proof-of-possession]</a>.</p>
 <p id="rfc.section.5.6.4.5.p.2">In addition to the use as a claim in a CWT, the "cnf" parameter is used in the following contexts with the following meaning: </p>
 
 <ul>
-  <li>In the token request C -&gt; AS, to indicate the client's raw public key, or the key-identifier of a previously established key between C and RS.</li>
-  <li>In the token response AS -&gt; C, to indicate the symmetric key generated by the AS for proof-of-possession.</li>
-  <li>In the introspection response AS -&gt; RS, to indicate the proof-of-possession	key bound to the introspected token.</li>
-  <li>In the client token AS -&gt; RS -&gt; C, to indicate the proof-of-possession	key bound to the access token.</li>
+<li>In the token request C -&gt; AS, to indicate the client's raw public key, or the key-identifier of a previously established key between C and RS.</li>
+<li>In the token response AS -&gt; C, to indicate the symmetric key generated by the AS for proof-of-possession.</li>
+<li>In the introspection response AS -&gt; RS, to indicate the proof-of-possession	key bound to the introspected token.</li>
+<li>In the client token AS -&gt; RS -&gt; C, to indicate the proof-of-possession	key bound to the access token.</li>
 </ul>
 <p id="rfc.section.5.6.4.5.p.3">Note that the COSE_Key structure in a "cnf" claim or parameter may contain an "alg" or "key_ops" parameter.  If such parameters are present, a client MUST NOT use a key that is not compatible with the profile or proof-of-possession algorithm according to those parameters. An RS MUST reject a proof-of-possession using such a key.  </p>
-<h1 id="rfc.section.5.6.5"><a href="#rfc.section.5.6.5">5.6.5.</a> <a href="#tokenCborParams" id="tokenCborParams">Mapping parameters to CBOR</a></h1>
-<p id="rfc.section.5.6.5.p.1">All OAuth parameters in access token requests and responses MUST be mapped to CBOR types as specified in <a href="#fig:cborTokenParameters">Figure 12</a>, using the given integer abbreviation for the key.</p>
-<p id="rfc.section.5.6.5.p.2">Note that we have aligned these abbreviations with the claim abbreviations defined in <a href="#I-D.ietf-ace-cbor-web-token">[I-D.ietf-ace-cbor-web-token]</a>.</p>
-<div id="rfc.figure.12"/>
-<div id="fig:cborTokenParameters"/>
+<h1 id="rfc.section.5.6.5">
+<a href="#rfc.section.5.6.5">5.6.5.</a> <a href="#tokenCborParams" id="tokenCborParams">Mapping Parameters to CBOR</a>
+</h1>
+<p id="rfc.section.5.6.5.p.1">All OAuth parameters in access token requests and responses MUST be mapped to CBOR types as specified in <a href="#fig:cborTokenParameters" class="xref">Figure 12</a>, using the given integer abbreviation for the key, if a CBOR encoding is used.</p>
+<p id="rfc.section.5.6.5.p.2">Note that we have aligned these abbreviations with the claim abbreviations defined in <a href="#I-D.ietf-ace-cbor-web-token" class="xref">[I-D.ietf-ace-cbor-web-token]</a>.</p>
+<div id="rfc.figure.12"></div>
+<div id="fig:cborTokenParameters"></div>
 <pre>
         /-------------------+----------+---------------------\
         | Name              | CBOR Key | Value Type          |
@@ -1074,18 +1229,22 @@ Payload:
         \-------------------+----------+---------------------/
       </pre>
 <p class="figure">Figure 12: CBOR mappings used in token requests</p>
-<p/>
-<h1 id="rfc.section.5.7"><a href="#rfc.section.5.7">5.7.</a> <a href="#introspectionEndpoint" id="introspectionEndpoint">The 'Introspect' Endpoint</a></h1>
-<p id="rfc.section.5.7.p.1">Token introspection <a href="#RFC7662">[RFC7662]</a> can be OPTIONALLY provided by the AS, and is then used by the RS and potentially the client to query the AS for metadata about a given token e.g., validity or scope. Analogous to the protocol defined in RFC 7662 <a href="#RFC7662">[RFC7662]</a> for HTTP and JSON, this section defines adaptations to more constrained  environments using CBOR and leaving the choice of the application protocol to the profile.</p>
+<p></p>
+<h1 id="rfc.section.5.7">
+<a href="#rfc.section.5.7">5.7.</a> <a href="#introspectionEndpoint" id="introspectionEndpoint">The 'Introspect' Endpoint</a>
+</h1>
+<p id="rfc.section.5.7.p.1">Token introspection <a href="#RFC7662" class="xref">[RFC7662]</a> can be OPTIONALLY provided by the AS, and is then used by the RS and potentially the client to query the AS for metadata about a given token e.g., validity or scope. Analogous to the protocol defined in RFC 7662 <a href="#RFC7662" class="xref">[RFC7662]</a> for HTTP and JSON, this section defines adaptations to more constrained  environments using CBOR and leaving the choice of the application protocol to the profile.</p>
 <p id="rfc.section.5.7.p.2">Communication between the RS and the introspection endpoint at the AS MUST be integrity protected and encrypted.  Furthermore AS and RS MUST perform mutual authentication.  Finally the AS SHOULD verify that the RS has the right to access introspection information about the provided token.  Profiles of this framework that support introspection MUST specify how authentication and communication security between RS and AS is implemented.</p>
 <p id="rfc.section.5.7.p.3">The default name of this endpoint in an url-path is 'introspect', however implementations are not required to use this name and can define their own instead.</p>
 <p id="rfc.section.5.7.p.4">The figures of this section uses CBOR diagnostic notation without the integer abbreviations for the parameters or their values for better readability.  </p>
 <p id="rfc.section.5.7.p.5">Note that supporting introspection is OPTIONAL for implementations of this framework.</p>
-<h1 id="rfc.section.5.7.1"><a href="#rfc.section.5.7.1">5.7.1.</a> <a href="#introRS2AS" id="introRS2AS">RS-to-AS Request</a></h1>
+<h1 id="rfc.section.5.7.1">
+<a href="#rfc.section.5.7.1">5.7.1.</a> <a href="#introRS2AS" id="introRS2AS">RS-to-AS Request</a>
+</h1>
 <p id="rfc.section.5.7.1.p.1">The RS sends a POST request to the introspection endpoint at the AS, the profile MUST specify the Content-Type and wrapping of the payload.  The payload MUST be encoded as a CBOR map with a "token" parameter containing either the access token or a reference to the token (e.g., the cti).  Further optional parameters representing additional context that is known by the RS to aid the AS in its response MAY be included.</p>
-<p id="rfc.section.5.7.1.p.2">The same parameters are required and optional as in section 2.1 of RFC 7662 <a href="#RFC7662">[RFC7662]</a>.</p>
-<div id="rfc.figure.13"/>
-<div id="fig:introReq"/>
+<p id="rfc.section.5.7.1.p.2">The same parameters are required and optional as in Section 2.1 of RFC 7662 <a href="#RFC7662" class="xref">[RFC7662]</a>.</p>
+<div id="rfc.figure.13"></div>
+<div id="fig:introReq"></div>
 <pre>
 Header: POST (Code=0.02)
 Uri-Host: "as.example.com"
@@ -1098,23 +1257,25 @@ Payload:
 }
        </pre>
 <p class="figure">Figure 13: Example introspection request.</p>
-<p id="rfc.section.5.7.1.p.3">For example, <a href="#fig:introReq">Figure 13</a> shows a RS calling the token introspection endpoint at the AS to query about an OAuth 2.0 proof-of-possession token.  Note that object security based on COSE is assumed in this example, therefore the Content-Type is "application/cose+cbor".  </p>
-<h1 id="rfc.section.5.7.2"><a href="#rfc.section.5.7.2">5.7.2.</a> <a href="#introAS2RS" id="introAS2RS">AS-to-RS Response</a></h1>
-<p id="rfc.section.5.7.2.p.1">If the introspection request is authorized and successfully processed, the AS sends a response with the response code equivalent to the CoAP code 2.01 (Created).  If the introspection request was invalid, not authorized or couldn't be processed the AS returns an error response as described in <a href="#errorsIntro">Section 5.7.3</a>.</p>
-<p id="rfc.section.5.7.2.p.2">In a successful response, the AS encodes the response parameters in a CBOR map including with the same required and optional parameters as in section 2.2. of RFC 7662 <a href="#RFC7662">[RFC7662]</a> with the following additions: </p>
+<p id="rfc.section.5.7.1.p.3">For example, <a href="#fig:introReq" class="xref">Figure 13</a> shows a RS calling the token introspection endpoint at the AS to query about an OAuth 2.0 proof-of-possession token.  Note that object security based on COSE is assumed in this example, therefore the Content-Type is "application/cose+cbor".  </p>
+<h1 id="rfc.section.5.7.2">
+<a href="#rfc.section.5.7.2">5.7.2.</a> <a href="#introAS2RS" id="introAS2RS">AS-to-RS Response</a>
+</h1>
+<p id="rfc.section.5.7.2.p.1">If the introspection request is authorized and successfully processed, the AS sends a response with the response code equivalent to the CoAP code 2.01 (Created).  If the introspection request was invalid, not authorized or couldn't be processed the AS returns an error response as described in <a href="#errorsIntro" class="xref">Section 5.7.3</a>.</p>
+<p id="rfc.section.5.7.2.p.2">In a successful response, the AS encodes the response parameters in a CBOR map including with the same required and optional parameters as in Section 2.2. of RFC 7662 <a href="#RFC7662" class="xref">[RFC7662]</a> with the following additions: </p>
 
 <dl>
-  <dt>cnf</dt>
-  <dd style="margin-left: 8">OPTIONAL.   This field contains information about the proof-of-possession  key that binds the client to the access token.  See <a href="#paramCnf">Section 5.6.4.5</a> for more details on the use of the "cnf" parameter.</dd>
-  <dt>profile</dt>
-  <dd style="margin-left: 8">OPTIONAL.  This indicates the profile that the RS MUST use with the client.  See <a href="#paramProfile">Section 5.6.4.4</a> for more details on the formatting of this parameter.</dd>
-  <dt>client_token</dt>
-  <dd style="margin-left: 8">OPTIONAL.  This parameter contains information that the RS MUST pass on to the client.  See <a href="#clientToken">Section 5.7.4</a> for more details.</dd>
+<dt>cnf</dt>
+<dd style="margin-left: 8">OPTIONAL.   This field contains information about the proof-of-possession  key that binds the client to the access token.  See <a href="#paramCnf" class="xref">Section 5.6.4.5</a> for more details on the use of the "cnf" parameter.</dd>
+<dt>profile</dt>
+<dd style="margin-left: 8">OPTIONAL.  This indicates the profile that the RS MUST use with the client.  See <a href="#paramProfile" class="xref">Section 5.6.4.4</a> for more details on the formatting of this parameter.</dd>
+<dt>client_token</dt>
+<dd style="margin-left: 8">OPTIONAL.  This parameter contains information that the RS MUST pass on to the client.  See <a href="#clientToken" class="xref">Section 5.7.4</a> for more details.</dd>
 </dl>
 
 <p> </p>
-<div id="rfc.figure.14"/>
-<div id="fig:introRes"/>
+<div id="rfc.figure.14"></div>
+<div id="fig:introRes"></div>
 <pre>
 Header: Created Code=2.01)
 Content-Type: "application/cbor"
@@ -1135,24 +1296,28 @@ Payload:
 }
       </pre>
 <p class="figure">Figure 14: Example introspection response.</p>
-<p id="rfc.section.5.7.2.p.3">For example, <a href="#fig:introRes">Figure 14</a> shows an AS response to the introspection request in <a href="#fig:introReq">Figure 13</a>.  Note that transport layer security is assumed in this example, therefore the Content-Type is "application/cbor".  </p>
-<h1 id="rfc.section.5.7.3"><a href="#rfc.section.5.7.3">5.7.3.</a> <a href="#errorsIntro" id="errorsIntro">Error Response</a></h1>
-<p id="rfc.section.5.7.3.p.1">The error responses for CoAP-based interactions with the AS are equivalent to the ones for HTTP-based interactions as defined in section 2.3 of <a href="#RFC7662">[RFC7662]</a>, with the following differences: </p>
+<p id="rfc.section.5.7.2.p.3">For example, <a href="#fig:introRes" class="xref">Figure 14</a> shows an AS response to the introspection request in <a href="#fig:introReq" class="xref">Figure 13</a>.  Note that transport layer security is assumed in this example, therefore the Content-Type is "application/cbor".  </p>
+<h1 id="rfc.section.5.7.3">
+<a href="#rfc.section.5.7.3">5.7.3.</a> <a href="#errorsIntro" id="errorsIntro">Error Response</a>
+</h1>
+<p id="rfc.section.5.7.3.p.1">The error responses for CoAP-based interactions with the AS are equivalent to the ones for HTTP-based interactions as defined in Section 2.3 of <a href="#RFC7662" class="xref">[RFC7662]</a>, with the following differences: </p>
 
 <ul>
-  <li>If content is sent, the Content-Type MUST be set according to the specification of the communication security profile, and the content payload MUST be encoded as a CBOR map.</li>
-  <li>If the credentials used by the RS are invalid the AS MUST respond with the response code equivalent to the CoAP code 4.01 (Unauthorized) and use the required and optional parameters from section 5.2 in RFC 6749 <a href="#RFC6749">[RFC6749]</a>.</li>
-  <li>If the RS does not have the right to perform this introspection request, the AS MUST respond with a response code equivalent to the CoAP code 4.03 (Forbidden).  In this case no payload is returned.</li>
-  <li>The parameters "error", "error_description" and "error_uri" MUST be abbreviated using the codes specified in <a href="#fig:cborTokenParameters">Figure 12</a>.</li>
-  <li>The error codes MUST be abbreviated using the codes specified in <a href="#fig:cborErrorCodes">Figure 10</a>.</li>
+<li>If content is sent, the Content-Type MUST be set according to the specification of the communication security profile, and the content payload MUST be encoded as a CBOR map.</li>
+<li>If the credentials used by the RS are invalid the AS MUST respond with the response code equivalent to the CoAP code 4.01 (Unauthorized) and use the required and optional parameters from Section 5.2 in RFC 6749 <a href="#RFC6749" class="xref">[RFC6749]</a>.</li>
+<li>If the RS does not have the right to perform this introspection request, the AS MUST respond with a response code equivalent to the CoAP code 4.03 (Forbidden).  In this case no payload is returned.</li>
+<li>The parameters "error", "error_description" and "error_uri" MUST be abbreviated using the codes specified in <a href="#fig:cborTokenParameters" class="xref">Figure 12</a>.</li>
+<li>The error codes MUST be abbreviated using the codes specified in <a href="#fig:cborErrorCodes" class="xref">Figure 10</a>.</li>
 </ul>
 
 <p> </p>
 <p id="rfc.section.5.7.3.p.2">Note that a properly formed and authorized query for an inactive or otherwise invalid token does not warrant an error response by this specification.  In these cases, the authorization server MUST instead respond with an introspection response with the "active" field set to "false".</p>
-<h1 id="rfc.section.5.7.4"><a href="#rfc.section.5.7.4">5.7.4.</a> <a href="#clientToken" id="clientToken">Client Token</a></h1>
+<h1 id="rfc.section.5.7.4">
+<a href="#rfc.section.5.7.4">5.7.4.</a> <a href="#clientToken" id="clientToken">Client Token</a>
+</h1>
 <p id="rfc.section.5.7.4.p.1">In cases where the client has limited connectivity and needs to get access to a previously unknown resource servers, this framework suggests the following OPTIONAL approach:  The client is pre-configured with a long-term access token, which is not self-contained (i.e. it is only a reference to a token at the AS) when it is commissioned.  When the client then tries to access a RS it transmits this access token.  The RS then performs token introspection to learn what access this token grants.  In the introspection response, the AS also relays information for the client, such as the proof-of-possession key, through the RS.  The RS passes on this Client Token to the client in response to the submission of the token.</p>
-<div id="rfc.figure.15"/>
-<div id="fig:client_token"/>
+<div id="rfc.figure.15"></div>
+<div id="fig:client_token"></div>
 <pre>
                   Resource       Authorization
  Client            Server           Server
@@ -1174,27 +1339,29 @@ C:  +---------------&gt;|                |
     | + Client Token |
     </pre>
 <p class="figure">Figure 15: Use of the client_token parameter.</p>
-<p id="rfc.section.5.7.4.p.2">The client_token parameter is designed to carry such information, and is intended to be used as described in <a href="#fig:client_token">Figure 15</a>.  </p>
+<p id="rfc.section.5.7.4.p.2">The client_token parameter is designed to carry such information, and is intended to be used as described in <a href="#fig:client_token" class="xref">Figure 15</a>.  </p>
 <p id="rfc.section.5.7.4.p.3">The client token is a COSE_Encrypted object, containing as payload a CBOR map with the following claims: </p>
 
 <dl>
-  <dt>cnf</dt>
-  <dd style="margin-left: 8">REQUIRED if the token type is "pop", OPTIONAL otherwise.  Contains information about the proof-of-possession key the client is to use with its access token.  See <a href="#paramCnf">Section 5.6.4.5</a>.</dd>
-  <dt>token_type</dt>
-  <dd style="margin-left: 8">OPTIONAL. See <a href="#paramTokenType">Section 5.6.4.3</a>.</dd>
-  <dt>profile</dt>
-  <dd style="margin-left: 8">REQUIRED. See <a href="#paramProfile">Section 5.6.4.4</a>.</dd>
-  <dt>rs_cnf</dt>
-  <dd style="margin-left: 8">OPTIONAL. Contains information about the key that the RS uses to authenticate towards the client.  If the key is symmetric then this claim MUST NOT be part of the Client Token, since this is the same key as the one specified through the "cnf" claim.  This claim uses the same encoding as the "cnf" parameter.  See <a href="#paramProfile">Section 5.6.4.4</a>.</dd>
+<dt>cnf</dt>
+<dd style="margin-left: 8">REQUIRED if the token type is "pop", OPTIONAL otherwise.  Contains information about the proof-of-possession key the client is to use with its access token.  See <a href="#paramCnf" class="xref">Section 5.6.4.5</a>.</dd>
+<dt>token_type</dt>
+<dd style="margin-left: 8">OPTIONAL. See <a href="#paramTokenType" class="xref">Section 5.6.4.3</a>.</dd>
+<dt>profile</dt>
+<dd style="margin-left: 8">REQUIRED. See <a href="#paramProfile" class="xref">Section 5.6.4.4</a>.</dd>
+<dt>rs_cnf</dt>
+<dd style="margin-left: 8">OPTIONAL. Contains information about the key that the RS uses to authenticate towards the client.  If the key is symmetric then this claim MUST NOT be part of the Client Token, since this is the same key as the one specified through the "cnf" claim.  This claim uses the same encoding as the "cnf" parameter.  See <a href="#paramProfile" class="xref">Section 5.6.4.4</a>.</dd>
 </dl>
 
 <p> </p>
 <p id="rfc.section.5.7.4.p.4">The AS encrypts this token using a key shared between the AS and the client, so that only the client can decrypt it and access its payload.  How this key is established is out of scope of this framework, however it can be established at the same time at which the client's long term token is created.</p>
 <p id="rfc.section.5.7.4.p.5">An RS that is configured to perform introspection, MUST do so immediately after receiving an access token, in order to be able to return a potential client token to the client.  This does not preclude the RS to perform additional introspection asynchronously, e.g., when the token is later used.</p>
-<h1 id="rfc.section.5.7.5"><a href="#rfc.section.5.7.5">5.7.5.</a> <a href="#introParamsCbor" id="introParamsCbor">Mapping Introspection parameters to CBOR</a></h1>
-<p id="rfc.section.5.7.5.p.1">The introspection request and response parameters MUST be mapped to CBOR types as specified in <a href="#fig:cborIntrospectionParameters">Figure 16</a>, using the given integer abbreviation for the key.</p>
-<div id="rfc.figure.16"/>
-<div id="fig:cborIntrospectionParameters"/>
+<h1 id="rfc.section.5.7.5">
+<a href="#rfc.section.5.7.5">5.7.5.</a> <a href="#introParamsCbor" id="introParamsCbor">Mapping Introspection parameters to CBOR</a>
+</h1>
+<p id="rfc.section.5.7.5.p.1">The introspection request and response parameters MUST be mapped to CBOR types as specified in <a href="#fig:cborIntrospectionParameters" class="xref">Figure 16</a>, using the given integer abbreviation for the key.</p>
+<div id="rfc.figure.16"></div>
+<div id="fig:cborIntrospectionParameters"></div>
 <pre>
     /-----------------+----------+-----------------------\
     | Parameter name  | CBOR Key | Value Type            |
@@ -1220,603 +1387,744 @@ C:  +---------------&gt;|                |
     \-----------------+----------+-----------------------/
         </pre>
 <p class="figure">Figure 16: CBOR Mappings to Token Introspection Parameters.</p>
-<p id="rfc.section.5.7.5.p.2">Note that we have aligned these abbreviations with the claim abbreviations defined in <a href="#I-D.ietf-ace-cbor-web-token">[I-D.ietf-ace-cbor-web-token]</a>.  </p>
-<h1 id="rfc.section.5.8"><a href="#rfc.section.5.8">5.8.</a> <a href="#accessToken" id="accessToken">The Access Token</a></h1>
-<p id="rfc.section.5.8.p.1">This framework RECOMMENDS the use of CBOR web token (CWT) as specified in <a href="#I-D.ietf-ace-cbor-web-token">[I-D.ietf-ace-cbor-web-token]</a>.  </p>
-<p id="rfc.section.5.8.p.2">In order to facilitate offline processing of access tokens, this draft uses the "cnf" claim from <a href="#I-D.ietf-ace-cwt-proof-of-possession">[I-D.ietf-ace-cwt-proof-of-possession]</a> and specifies the "scope" claim for both JSON and CBOR web tokens.</p>
-<p id="rfc.section.5.8.p.3">The "scope" claim explicitly encodes the scope of a given access token.  This claim follows the same encoding rules as defined in section 3.3 of <a href="#RFC6749">[RFC6749]</a>, but in addition implementers MAY use byte arrays as scope values, to achieve compact encoding of large scope elements.  The meaning of a specific scope value is application specific and expected to be known to the RS running that application.</p>
-<h1 id="rfc.section.5.8.1"><a href="#rfc.section.5.8.1">5.8.1.</a> <a href="#tokenAuthInfoEndpoint" id="tokenAuthInfoEndpoint">The 'Authorization Information' Endpoint</a></h1>
+<p id="rfc.section.5.7.5.p.2">Note that we have aligned these abbreviations with the claim abbreviations defined in <a href="#I-D.ietf-ace-cbor-web-token" class="xref">[I-D.ietf-ace-cbor-web-token]</a>.  </p>
+<h1 id="rfc.section.5.8">
+<a href="#rfc.section.5.8">5.8.</a> <a href="#accessToken" id="accessToken">The Access Token</a>
+</h1>
+<p id="rfc.section.5.8.p.1">This framework RECOMMENDS the use of CBOR web token (CWT) as specified in <a href="#I-D.ietf-ace-cbor-web-token" class="xref">[I-D.ietf-ace-cbor-web-token]</a>.  </p>
+<p id="rfc.section.5.8.p.2">In order to facilitate offline processing of access tokens, this draft uses the "cnf" claim from <a href="#I-D.ietf-ace-cwt-proof-of-possession" class="xref">[I-D.ietf-ace-cwt-proof-of-possession]</a> and specifies the "scope" claim for both JSON and CBOR web tokens.</p>
+<p id="rfc.section.5.8.p.3">The "scope" claim explicitly encodes the scope of a given access token.  This claim follows the same encoding rules as defined in Section 3.3 of <a href="#RFC6749" class="xref">[RFC6749]</a>, but in addition implementers MAY use byte arrays as scope values, to achieve compact encoding of large scope elements.  The meaning of a specific scope value is application specific and expected to be known to the RS running that application.</p>
+<h1 id="rfc.section.5.8.1">
+<a href="#rfc.section.5.8.1">5.8.1.</a> <a href="#tokenAuthInfoEndpoint" id="tokenAuthInfoEndpoint">The 'Authorization Information' Endpoint</a>
+</h1>
 <p id="rfc.section.5.8.1.p.1">The access token, containing authorization information and information about the key used by the client, needs to be transported to the RS so that the RS can authenticate and authorize the client request.</p>
 <p id="rfc.section.5.8.1.p.2">This section defines a method for transporting the access token to the RS using a RESTful protocol such as CoAP. Profiles of this framework MAY define other methods for token transport.  </p>
 <p id="rfc.section.5.8.1.p.3">The method consists of an authz-info endpoint, implemented by the RS.  A client using this method MUST make a POST request to the authz-info endpoint at the RS with the access token in the payload. The RS receiving the token MUST verify the validity of the token.  If the token is valid, the RS MUST respond to the POST request with 2.01 (Created).  This response MAY contain an identifier of the token (e.g., the cti for a CWT) as a payload, in order to allow the client to refer to the token.</p>
 <p id="rfc.section.5.8.1.p.4">The RS MUST be prepared to store at least one access token for future use. This is a difference to how access tokens are handled in OAuth 2.0, where the access token is typically sent along with each request, and therefore not stored at the RS.</p>
 <p id="rfc.section.5.8.1.p.5">If the token is not valid, the RS MUST respond with a response code equivalent to the CoAP code 4.01 (Unauthorized).  If the token is valid but the audience of the token does not match the RS, the RS MUST respond with a response code equivalent to the CoAP code 4.03 (Forbidden).  If the token is valid but is associated to claims that the RS cannot process (e.g., an unknown scope) the RS MUST respond with a response code equivalent to the CoAP code 4.00 (Bad Request). In the latter case the RS MAY provide additional information in the error response, in order to clarify what went wrong.  </p>
-<p id="rfc.section.5.8.1.p.6">The RS MAY make an introspection request to validate the token before responding to the POST request to the authz-info endpoint.  If the introspection response contains a client token (<a href="#clientToken">Section 5.7.4</a>) then this token SHALL be included in the payload of the 2.01 (Created) response.  </p>
+<p id="rfc.section.5.8.1.p.6">The RS MAY make an introspection request to validate the token before responding to the POST request to the authz-info endpoint.  If the introspection response contains a client token (<a href="#clientToken" class="xref">Section 5.7.4</a>) then this token SHALL be included in the payload of the 2.01 (Created) response.  </p>
 <p id="rfc.section.5.8.1.p.7">Profiles MUST specify how the authz-info endpoint is protected.  Note that since the token contains information that allow the client and the RS to establish a security context in the first place, mutual authentication may not be possible at this point.</p>
 <p id="rfc.section.5.8.1.p.8">The default name of this endpoint in an url-path is 'authz-info', however implementations are not required to use this name and can define their own instead.</p>
-<h1 id="rfc.section.5.8.2"><a href="#rfc.section.5.8.2">5.8.2.</a> <a href="#tokenValidity" id="tokenValidity">Token Expiration</a></h1>
+<h1 id="rfc.section.5.8.2">
+<a href="#rfc.section.5.8.2">5.8.2.</a> <a href="#tokenValidity" id="tokenValidity">Token Expiration</a>
+</h1>
 <p id="rfc.section.5.8.2.p.1">Depending on the capabilities of the RS, there are various ways in which it can verify the validity of a received access token.  Here follows a list of the possibilities including what functionality they require of the RS.</p>
-<p/>
+<p></p>
 
 <ul>
-  <li>The token is a CWT and includes an "exp" claim and possibly the "nbf" claim.  The RS verifies these by comparing them to values from its internal clock as defined in <a href="#RFC7519">[RFC7519]</a>.  In this case the RS's internal clock must reflect the current date and time, or at least be synchronized with the AS's clock.  How this clock synchronization would be performed is out of scope for this specification.</li>
-  <li>The RS verifies the validity of the token by performing an introspection request as specified in <a href="#introspectionEndpoint">Section 5.7</a>.  This requires the RS to have a reliable network connection to the AS and to be able to handle two secure sessions in parallel (C to RS and AS to RS).</li>
-  <li>The RS and the AS both store a sequence number linked to their common security association.  The AS increments this number for each access token it issues and includes it in the access token, which is a CWT.  The RS keeps track of the most recently received sequence number, and only accepts tokens as valid, that are in a certain range around this number.  This method does only require the RS to keep track of the sequence number.  The method does not provide timely expiration, but it makes sure that older tokens cease to be valid after a certain number of newer ones got issued.  For a constrained RS with no network connectivity and no means of reliably measuring time, this is the best that can be achieved.</li>
+<li>The token is a CWT and includes an "exp" claim and possibly the "nbf" claim.  The RS verifies these by comparing them to values from its internal clock as defined in <a href="#RFC7519" class="xref">[RFC7519]</a>.  In this case the RS's internal clock must reflect the current date and time, or at least be synchronized with the AS's clock.  How this clock synchronization would be performed is out of scope for this specification.</li>
+<li>The RS verifies the validity of the token by performing an introspection request as specified in <a href="#introspectionEndpoint" class="xref">Section 5.7</a>.  This requires the RS to have a reliable network connection to the AS and to be able to handle two secure sessions in parallel (C to RS and AS to RS).</li>
+<li>The RS and the AS both store a sequence number linked to their common security association.  The AS increments this number for each access token it issues and includes it in the access token, which is a CWT.  The RS keeps track of the most recently received sequence number, and only accepts tokens as valid, that are in a certain range around this number.  This method does only require the RS to keep track of the sequence number.  The method does not provide timely expiration, but it makes sure that older tokens cease to be valid after a certain number of newer ones got issued.  For a constrained RS with no network connectivity and no means of reliably measuring time, this is the best that can be achieved.</li>
 </ul>
-<p id="rfc.section.5.8.2.p.3">If a token that authorizes a long running request such as a CoAP Observe <a href="#RFC7641">[RFC7641]</a> expires, the RS MUST send an error response with the response code 4.01 Unauthorized to the client and then terminate processing the long running request.</p>
-<h1 id="rfc.section.6"><a href="#rfc.section.6">6.</a> <a href="#security" id="security">Security Considerations</a></h1>
-<p id="rfc.section.6.p.1">Security considerations applicable to authentication and authorization in RESTful environments provided in OAuth 2.0 <a href="#RFC6749">[RFC6749]</a> apply to this work, as well as the security considerations from <a href="#I-D.ietf-ace-actors">[I-D.ietf-ace-actors]</a>.  Furthermore <a href="#RFC6819">[RFC6819]</a> provides additional security considerations for OAuth which apply to IoT deployments as well.</p>
+<p id="rfc.section.5.8.2.p.3">If a token that authorizes a long running request such as a CoAP Observe <a href="#RFC7641" class="xref">[RFC7641]</a> expires, the RS MUST send an error response with the response code 4.01 Unauthorized to the client and then terminate processing the long running request.</p>
+<h1 id="rfc.section.6">
+<a href="#rfc.section.6">6.</a> <a href="#security" id="security">Security Considerations</a>
+</h1>
+<p id="rfc.section.6.p.1">Security considerations applicable to authentication and authorization in RESTful environments provided in OAuth 2.0 <a href="#RFC6749" class="xref">[RFC6749]</a> apply to this work, as well as the security considerations from <a href="#I-D.ietf-ace-actors" class="xref">[I-D.ietf-ace-actors]</a>.  Furthermore <a href="#RFC6819" class="xref">[RFC6819]</a> provides additional security considerations for OAuth which apply to IoT deployments as well.</p>
 <p id="rfc.section.6.p.2">A large range of threats can be mitigated by protecting the contents of the access token by using a digital signature or a keyed message digest (MAC) or an Authenticated Encryption with Associated Data (AEAD) algorithm.  Consequently, the token integrity protection MUST be applied to prevent the token from being modified, particularly since it contains a reference to the symmetric key or the asymmetric key.  If the access token contains the symmetric key, this symmetric key MUST be encrypted by the authorization server so that only the resource server can decrypt it.  Note that using an AEAD algorithm is preferable over using a MAC unless the message needs to be publicly readable.</p>
 <p id="rfc.section.6.p.3">It is important for the authorization server to include the identity of the intended recipient (the audience), typically a single resource server (or a list of resource servers), in the token.  Using a single shared secret with multiple resource servers to simplify key management is NOT RECOMMENDED since the benefit from using the proof-of-possession concept is significantly reduced.</p>
-<p id="rfc.section.6.p.4">The authorization server MUST offer confidentiality protection for any interactions with the client.  This step is extremely important since the client may obtain the proof-of-possession key from the authorization server for use with a specific access token.  Not using confidentiality protection exposes this secret (and the access token) to an eavesdropper thereby completely negating proof-of-possession security.  Profiles MUST specify how confidentiality protection is provided, and additional protection can be applied by encrypting the token, for example encryption of CWTs is specified in section 5.1 of <a href="#I-D.ietf-ace-cbor-web-token">[I-D.ietf-ace-cbor-web-token]</a>.</p>
+<p id="rfc.section.6.p.4">The authorization server MUST offer confidentiality protection for any interactions with the client.  This step is extremely important since the client may obtain the proof-of-possession key from the authorization server for use with a specific access token.  Not using confidentiality protection exposes this secret (and the access token) to an eavesdropper thereby completely negating proof-of-possession security.  Profiles MUST specify how confidentiality protection is provided, and additional protection can be applied by encrypting the token, for example encryption of CWTs is specified in Section 5.1 of <a href="#I-D.ietf-ace-cbor-web-token" class="xref">[I-D.ietf-ace-cbor-web-token]</a>.</p>
 <p id="rfc.section.6.p.5">Developers MUST ensure that the ephemeral credentials (i.e., the private key or the session key) are not leaked to third parties.  An adversary in possession of the ephemeral credentials bound to the access token will be able to impersonate the client.  Be aware that this is a real risk with many constrained environments, since adversaries can often easily get physical access to the devices.</p>
 <p id="rfc.section.6.p.6">Clients can at any time request a new proof-of-possession capable access token.  If clients have that capability, the AS can keep the lifetime of the access token and the associated proof-of-possession key short and therefore use shorter proof-of-possession key sizes, which translate to a performance benefit for the client and for the resource server.  Shorter keys also lead to shorter messages (particularly with asymmetric keying material).</p>
 <p id="rfc.section.6.p.7">When authorization servers bind symmetric keys to access tokens, they SHOULD scope these access tokens to a specific permissions.  Furthermore access tokens using symmetric keys for proof-of-possession SHOULD NOT be targeted at an audience that contains more than one RS, since otherwise any RS in the audience that receives that access token can impersonate the client towards the other members of the audience.</p>
-<h1 id="rfc.section.6.1"><a href="#rfc.section.6.1">6.1.</a> <a href="#unprotected-as-information" id="unprotected-as-information">Unprotected AS Information</a></h1>
-<p id="rfc.section.6.1.p.1">Initially, no secure channel exists to protect the communication between C and RS. Thus, C cannot determine if the AS information contained in an unprotected response from RS to an unauthorized request (c.f. <a href="#asInfo">Section 5.1.2</a>) is authentic. It is therefore advisable to provide C with a (possibly hard-coded) list of trustworthy authorization servers. AS information responses referring to a URI not listed there would be ignored.</p>
-<h1 id="rfc.section.6.2"><a href="#rfc.section.6.2">6.2.</a> <a href="#nonce" id="nonce">Use of Nonces for Replay Protection</a></h1>
+<h1 id="rfc.section.6.1">
+<a href="#rfc.section.6.1">6.1.</a> <a href="#unprotected-as-information" id="unprotected-as-information">Unprotected AS Information</a>
+</h1>
+<p id="rfc.section.6.1.p.1">Initially, no secure channel exists to protect the communication between C and RS. Thus, C cannot determine if the AS information contained in an unprotected response from RS to an unauthorized request (c.f. <a href="#asInfo" class="xref">Section 5.1.2</a>) is authentic. It is therefore advisable to provide C with a (possibly hard-coded) list of trustworthy authorization servers. AS information responses referring to a URI not listed there would be ignored.</p>
+<h1 id="rfc.section.6.2">
+<a href="#rfc.section.6.2">6.2.</a> <a href="#nonce" id="nonce">Use of Nonces for Replay Protection</a>
+</h1>
 <p id="rfc.section.6.2.p.1">RS may add a nonce to the AS Information message sent as a response to an unauthorized request to ensure freshness of an Access Token subsequently presented to RS. While a timestamp of some granularity would be sufficient to protect against replay attacks, using randomized nonce is preferred to prevent disclosure of information about RS&#8217;s internal clock characteristics.</p>
-<h1 id="rfc.section.6.3"><a href="#rfc.section.6.3">6.3.</a> <a href="#mixnmatch" id="mixnmatch">Combining profiles</a></h1>
+<h1 id="rfc.section.6.3">
+<a href="#rfc.section.6.3">6.3.</a> <a href="#mixnmatch" id="mixnmatch">Combining profiles</a>
+</h1>
 <p id="rfc.section.6.3.p.1">There may exist reasonable use cases where implementers want to combine different profiles of this framework, e.g., using an MQTT profile between client and RS, while using a DTLS profile for interactions between client and AS. Profiles should be designed in a way that the security of a protocol interaction does not depend on the specific security mechanisms used in other protocol interactions.</p>
-<h1 id="rfc.section.6.4"><a href="#rfc.section.6.4">6.4.</a> <a href="#authzInfoLeak" id="authzInfoLeak">Error responses</a></h1>
+<h1 id="rfc.section.6.4">
+<a href="#rfc.section.6.4">6.4.</a> <a href="#authzInfoLeak" id="authzInfoLeak">Error responses</a>
+</h1>
 <p id="rfc.section.6.4.p.1">The various error responses defined in this framework may leak information to an adversary.  For example errors responses for requests to the Authorization Information endpoint can reveal information about an otherwise opaque access token to an adversary who has intercepted this token.  This framework is written under the assumption that, in general, the benefits of detailed error messages outweigh the risk due to information leakage. For particular use cases, where this assessment does not apply, detailed error messages can be replaced by more generic ones.</p>
-<h1 id="rfc.section.7"><a href="#rfc.section.7">7.</a> <a href="#privacy" id="privacy">Privacy Considerations</a></h1>
+<h1 id="rfc.section.7">
+<a href="#rfc.section.7">7.</a> <a href="#privacy" id="privacy">Privacy Considerations</a>
+</h1>
 <p id="rfc.section.7.p.1">Implementers and users should be aware of the privacy implications of the different possible deployments of this framework.</p>
 <p id="rfc.section.7.p.2">The AS is in a very central position and can potentially learn sensitive information about the clients requesting access tokens.  If the client credentials grant is used, the AS can track what kind of access the client intends to perform.  With other grants this can be prevented by the Resource Owner.  To do so, the resource owner needs to bind the grants it issues to anonymous, ephemeral credentials that do not allow the AS to link different grants and thus different access token requests by the same client.</p>
 <p id="rfc.section.7.p.3">If access tokens are only integrity protected and not encrypted, they may reveal information to attackers listening on the wire, or able to acquire the access tokens in some other way.  In the case of CWTs the token may e.g., reveal the audience, the scope and the confirmation method used by the client.  The latter may reveal the identity of the device or application running the client.  This may be linkable to the identity of the person using the client (if there is a person and not a machine-to-machine interaction).</p>
 <p id="rfc.section.7.p.4">Clients using asymmetric keys for proof-of-possession should be aware of the consequences of using the same key pair for proof-of-possession towards different RSs.  A set of colluding RSs or an attacker able to obtain the access tokens will be able to link the requests, or even to determine the client's identity.</p>
-<p id="rfc.section.7.p.5">An unprotected response to an unauthorized request (c.f.  <a href="#asInfo">Section 5.1.2</a>) may disclose information about RS and/or its existing relationship with C. It is advisable to include as little information as possible in an unencrypted response. Means of encrypting communication between C and RS already exist, more detailed information may be included with an error response to provide C with sufficient information to react on that particular error.</p>
-<h1 id="rfc.section.8"><a href="#rfc.section.8">8.</a> <a href="#iana" id="iana">IANA Considerations</a></h1>
+<p id="rfc.section.7.p.5">An unprotected response to an unauthorized request (c.f.  <a href="#asInfo" class="xref">Section 5.1.2</a>) may disclose information about RS and/or its existing relationship with C. It is advisable to include as little information as possible in an unencrypted response. Means of encrypting communication between C and RS already exist, more detailed information may be included with an error response to provide C with sufficient information to react on that particular error.</p>
+<h1 id="rfc.section.8">
+<a href="#rfc.section.8">8.</a> <a href="#iana" id="iana">IANA Considerations</a>
+</h1>
 <p id="rfc.section.8.p.1">This specification registers new parameters for OAuth and establishes registries for mappings to CBOR abbreviations.</p>
-<h1 id="rfc.section.8.1"><a href="#rfc.section.8.1">8.1.</a> <a href="#IANAASInformation" id="IANAASInformation">Authorization Server Information</a></h1>
+<h1 id="rfc.section.8.1">
+<a href="#rfc.section.8.1">8.1.</a> <a href="#IANAASInformation" id="IANAASInformation">Authorization Server Information</a>
+</h1>
 <p id="rfc.section.8.1.p.1">A new registry will be requested from IANA, entitled "Authorization Server Information". The registry is to be created as Expert Review Required.</p>
 <p id="rfc.section.8.1.p.2">The columns of this table are: </p>
 
 <dl>
-  <dt>Name</dt>
-  <dd style="margin-left: 8">The name of the parameter</dd>
-  <dt>CBOR Key</dt>
-  <dd style="margin-left: 8">The unsigned integer value abbreviating this parameter name.  Registration in the table is based on the value of the mapping requested.  Integer values between 1 and 255 are designated as Standards Track Document required.  Integer values from 256 to 65535 are designated as Specification Required.  Integer values greater than 65535 are designated as private use.</dd>
-  <dt>Value Type</dt>
-  <dd style="margin-left: 8">The CBOR data types allowable for the values of this parameter.</dd>
-  <dt>Reference</dt>
-  <dd style="margin-left: 8">This contains a pointer to the public specification of the grant type abbreviation, if one exists.</dd>
+<dt>Name</dt>
+<dd style="margin-left: 8">The name of the parameter</dd>
+<dt>CBOR Key</dt>
+<dd style="margin-left: 8">The unsigned integer value abbreviating this parameter name.  Registration in the table is based on the value of the mapping requested.  Integer values between 1 and 255 are designated as Standards Track Document required.  Integer values from 256 to 65535 are designated as Specification Required.  Integer values greater than 65535 are designated as private use.</dd>
+<dt>Value Type</dt>
+<dd style="margin-left: 8">The CBOR data types allowable for the values of this parameter.</dd>
+<dt>Reference</dt>
+<dd style="margin-left: 8">This contains a pointer to the public specification of the grant type abbreviation, if one exists.</dd>
 </dl>
-<p id="rfc.section.8.1.p.3">This registry will be initially populated by the values in <a href="#fig:asinfo">Figure 2</a>. The Reference column for all of these entries will be this document.</p>
-<h1 id="rfc.section.8.2"><a href="#rfc.section.8.2">8.2.</a> <a href="#IANAOAuthErrorCBORMappingsRegistry" id="IANAOAuthErrorCBORMappingsRegistry">OAuth Error Code CBOR Mappings Registry</a></h1>
+<p id="rfc.section.8.1.p.3">This registry will be initially populated by the values in <a href="#fig:asinfo" class="xref">Figure 2</a>. The Reference column for all of these entries will be this document.</p>
+<h1 id="rfc.section.8.2">
+<a href="#rfc.section.8.2">8.2.</a> <a href="#IANAOAuthErrorCBORMappingsRegistry" id="IANAOAuthErrorCBORMappingsRegistry">OAuth Error Code CBOR Mappings Registry</a>
+</h1>
 <p id="rfc.section.8.2.p.1">A new registry will be requested from IANA, entitled "OAuth Error Code CBOR Mappings Registry".  The registry is to be created as Expert Review Required.</p>
 <p id="rfc.section.8.2.p.2">The columns of this table are: </p>
 
 <dl>
-  <dt>Name</dt>
-  <dd style="margin-left: 8">The OAuth Error Code name, refers to the name in section 5.2. of <a href="#RFC6749">[RFC6749]</a> e.g., "invalid_request".</dd>
-  <dt>CBOR Key</dt>
-  <dd style="margin-left: 8">The unsigned integer value abbreviating this error code.  Registration in the table is based on the value of the mapping requested.  Integer values between 1 and 255 are designated as Standards Track Document required.  Integer values from 256 to 65535 are designated as Specification Required.  Integer values greater than 65535 are designated as private use.</dd>
-  <dt>Reference</dt>
-  <dd style="margin-left: 8">This contains a pointer to the public specification of the grant type abbreviation, if one exists.</dd>
+<dt>Name</dt>
+<dd style="margin-left: 8">The OAuth Error Code name, refers to the name in Section 5.2. of <a href="#RFC6749" class="xref">[RFC6749]</a> e.g., "invalid_request".</dd>
+<dt>CBOR Key</dt>
+<dd style="margin-left: 8">The unsigned integer value abbreviating this error code.  Registration in the table is based on the value of the mapping requested.  Integer values between 1 and 255 are designated as Standards Track Document required.  Integer values from 256 to 65535 are designated as Specification Required.  Integer values greater than 65535 are designated as private use.</dd>
+<dt>Reference</dt>
+<dd style="margin-left: 8">This contains a pointer to the public specification of the grant type abbreviation, if one exists.</dd>
 </dl>
-<p id="rfc.section.8.2.p.3">This registry will be initially populated by the values in <a href="#fig:cborErrorCodes">Figure 10</a>. The Reference column for all of these entries will be this document.</p>
-<h1 id="rfc.section.8.3"><a href="#rfc.section.8.3">8.3.</a> <a href="#IANAGrantTypeMappings" id="IANAGrantTypeMappings">OAuth Grant Type CBOR Mappings</a></h1>
+<p id="rfc.section.8.2.p.3">This registry will be initially populated by the values in <a href="#fig:cborErrorCodes" class="xref">Figure 10</a>. The Reference column for all of these entries will be this document.</p>
+<h1 id="rfc.section.8.3">
+<a href="#rfc.section.8.3">8.3.</a> <a href="#IANAGrantTypeMappings" id="IANAGrantTypeMappings">OAuth Grant Type CBOR Mappings</a>
+</h1>
 <p id="rfc.section.8.3.p.1">A new registry will be requested from IANA, entitled "OAuth Grant Type CBOR Mappings". The registry is to be created as Expert Review Required.</p>
 <p id="rfc.section.8.3.p.2">The columns of this table are: </p>
 
 <dl>
-  <dt>Name</dt>
-  <dd style="margin-left: 8">The name of the grant type as specified in Section 1.3 of <a href="#RFC6749">[RFC6749]</a>.</dd>
-  <dt>CBOR Key</dt>
-  <dd style="margin-left: 8">The unsigned integer value abbreviating this grant type.  Registration in the table is based on the value of the mapping requested.  Integer values between 1 and 255 are designated as Standards Track Document required.  Integer values from 256 to 65535 are designated as Specification Required.  Integer values greater than 65535 are designated as private use.</dd>
-  <dt>Reference</dt>
-  <dd style="margin-left: 8">This contains a pointer to the public specification of the grant type abbreviation, if one exists.</dd>
-  <dt>Original Specification</dt>
-  <dd style="margin-left: 8">This contains a pointer to the public specification of the grant type, if one exists.</dd>
+<dt>Name</dt>
+<dd style="margin-left: 8">The name of the grant type as specified in Section 1.3 of <a href="#RFC6749" class="xref">[RFC6749]</a>.</dd>
+<dt>CBOR Key</dt>
+<dd style="margin-left: 8">The unsigned integer value abbreviating this grant type.  Registration in the table is based on the value of the mapping requested.  Integer values between 1 and 255 are designated as Standards Track Document required.  Integer values from 256 to 65535 are designated as Specification Required.  Integer values greater than 65535 are designated as private use.</dd>
+<dt>Reference</dt>
+<dd style="margin-left: 8">This contains a pointer to the public specification of the grant type abbreviation, if one exists.</dd>
+<dt>Original Specification</dt>
+<dd style="margin-left: 8">This contains a pointer to the public specification of the grant type, if one exists.</dd>
 </dl>
-<p id="rfc.section.8.3.p.3">This registry will be initially populated by the values in <a href="#fig:grant_types">Figure 11</a>. The Reference column for all of these entries will be this document.</p>
-<h1 id="rfc.section.8.4"><a href="#rfc.section.8.4">8.4.</a> <a href="#IANAOAuthTokenType" id="IANAOAuthTokenType">OAuth Access Token Types</a></h1>
+<p id="rfc.section.8.3.p.3">This registry will be initially populated by the values in <a href="#fig:grant_types" class="xref">Figure 11</a>. The Reference column for all of these entries will be this document.</p>
+<h1 id="rfc.section.8.4">
+<a href="#rfc.section.8.4">8.4.</a> <a href="#IANAOAuthTokenType" id="IANAOAuthTokenType">OAuth Access Token Types</a>
+</h1>
 <p id="rfc.section.8.4.p.1">This specification registers the following new token type in the OAuth Access Token Types Registry</p>
-<p/>
+<p></p>
 
 <ul>
-  <li>Name: <samp>PoP</samp></li>
-  <li>Change Controller: IETF</li>
-  <li>Reference: [this document]</li>
+<li>Name: <samp>PoP</samp>
+</li>
+<li>Change Controller: IETF</li>
+<li>Reference: [this document]</li>
 </ul>
-<h1 id="rfc.section.8.5"><a href="#rfc.section.8.5">8.5.</a> <a href="#IANATokenTypeMappings" id="IANATokenTypeMappings">OAuth Token Type CBOR Mappings</a></h1>
+<h1 id="rfc.section.8.5">
+<a href="#rfc.section.8.5">8.5.</a> <a href="#IANATokenTypeMappings" id="IANATokenTypeMappings">OAuth Token Type CBOR Mappings</a>
+</h1>
 <p id="rfc.section.8.5.p.1">A new registry will be requested from IANA, entitled "Token Type CBOR Mappings".  The registry is to be created as Expert Review Required.</p>
 <p id="rfc.section.8.5.p.2">The columns of this table are: </p>
 
 <dl>
-  <dt>Name</dt>
-  <dd style="margin-left: 8">The name of token type as registered in the OAuth Access Token Types registry e.g., "Bearer".</dd>
-  <dt>CBOR Key</dt>
-  <dd style="margin-left: 8">The unsigned integer value abbreviating this access token type.  Registration in the table is based on the value of the mapping requested.  Integer values between 1 and 255 are designated as Standards Track Document required.  Integer values from 256 to 65535 are designated as Specification Required.  Integer values greater than 65535  are designated as private use.</dd>
-  <dt>Reference</dt>
-  <dd style="margin-left: 8">This contains a pointer to the public specification of the OAuth token type abbreviation, if one exists.</dd>
-  <dt>Original Specification</dt>
-  <dd style="margin-left: 8">This contains a pointer to the public specification of the grant type, if one exists.</dd>
+<dt>Name</dt>
+<dd style="margin-left: 8">The name of token type as registered in the OAuth Access Token Types registry e.g., "Bearer".</dd>
+<dt>CBOR Key</dt>
+<dd style="margin-left: 8">The unsigned integer value abbreviating this access token type.  Registration in the table is based on the value of the mapping requested.  Integer values between 1 and 255 are designated as Standards Track Document required.  Integer values from 256 to 65535 are designated as Specification Required.  Integer values greater than 65535  are designated as private use.</dd>
+<dt>Reference</dt>
+<dd style="margin-left: 8">This contains a pointer to the public specification of the OAuth token type abbreviation, if one exists.</dd>
+<dt>Original Specification</dt>
+<dd style="margin-left: 8">This contains a pointer to the public specification of the grant type, if one exists.</dd>
 </dl>
-<h1 id="rfc.section.8.5.1"><a href="#rfc.section.8.5.1">8.5.1.</a> <a href="#IANATokenTypeMappingsInitial" id="IANATokenTypeMappingsInitial">Initial Registry Contents</a></h1>
-<p/>
+<h1 id="rfc.section.8.5.1">
+<a href="#rfc.section.8.5.1">8.5.1.</a> <a href="#IANATokenTypeMappingsInitial" id="IANATokenTypeMappingsInitial">Initial Registry Contents</a>
+</h1>
+<p></p>
 
 <ul>
-  <li>Name: <samp>Bearer</samp></li>
-  <li>Value:  1</li>
-  <li>Reference:  [this document]</li>
-  <li>Original Specification:  <a href="#RFC6749">[RFC6749]</a></li>
+<li>Name: <samp>Bearer</samp>
+</li>
+<li>Value:  1</li>
+<li>Reference:  [this document]</li>
+<li>Original Specification:  <a href="#RFC6749" class="xref">[RFC6749]</a>
+</li>
 </ul>
 
 <p> </p>
-<p/>
+<p></p>
 
 <ul>
-  <li>Name: <samp>pop</samp></li>
-  <li>Value: 2</li>
-  <li>Reference: [this document]</li>
-  <li>Original Specification:  [this document]</li>
+<li>Name: <samp>pop</samp>
+</li>
+<li>Value: 2</li>
+<li>Reference: [this document]</li>
+<li>Original Specification:  [this document]</li>
 </ul>
 
 <p> </p>
-<h1 id="rfc.section.8.6"><a href="#rfc.section.8.6">8.6.</a> <a href="#IANATokenEndpointCBORMappingsRegistry" id="IANATokenEndpointCBORMappingsRegistry">ACE OAuth Profile Registry</a></h1>
+<h1 id="rfc.section.8.6">
+<a href="#rfc.section.8.6">8.6.</a> <a href="#IANATokenEndpointCBORMappingsRegistry" id="IANATokenEndpointCBORMappingsRegistry">ACE OAuth Profile Registry</a>
+</h1>
 <p id="rfc.section.8.6.p.1">A new registry will be requested from IANA, entitled "ACE Profile Registry".  The registry is to be created as Expert Review Required.</p>
 <p id="rfc.section.8.6.p.2">The columns of this table are: </p>
 
 <dl>
-  <dt>Name</dt>
-  <dd style="margin-left: 8">The name of the profile, to be used as value of the profile attribute.</dd>
-  <dt>Description</dt>
-  <dd style="margin-left: 8">Text giving an overview of the profile and the context it is developed for.</dd>
-  <dt>CBOR Key</dt>
-  <dd style="margin-left: 8">The unsigned integer value abbreviating this profile name.  Registration in the table is based on the value of the mapping requested.  Integer values between 1 and 255 are designated as Standards Track Document required.  Integer values from 256 to 65535 are designated as Specification Required.  Integer values greater than 65535 are designated as private use.</dd>
-  <dt>Reference</dt>
-  <dd style="margin-left: 8">This contains a pointer to the public specification of the profile abbreviation, if one exists.</dd>
+<dt>Name</dt>
+<dd style="margin-left: 8">The name of the profile, to be used as value of the profile attribute.</dd>
+<dt>Description</dt>
+<dd style="margin-left: 8">Text giving an overview of the profile and the context it is developed for.</dd>
+<dt>CBOR Key</dt>
+<dd style="margin-left: 8">The unsigned integer value abbreviating this profile name.  Registration in the table is based on the value of the mapping requested.  Integer values between 1 and 255 are designated as Standards Track Document required.  Integer values from 256 to 65535 are designated as Specification Required.  Integer values greater than 65535 are designated as private use.</dd>
+<dt>Reference</dt>
+<dd style="margin-left: 8">This contains a pointer to the public specification of the profile abbreviation, if one exists.</dd>
 </dl>
-<h1 id="rfc.section.8.7"><a href="#rfc.section.8.7">8.7.</a> <a href="#IANAOAuthParameterRegistration" id="IANAOAuthParameterRegistration">OAuth Parameter Registration</a></h1>
+<h1 id="rfc.section.8.7">
+<a href="#rfc.section.8.7">8.7.</a> <a href="#IANAOAuthParameterRegistration" id="IANAOAuthParameterRegistration">OAuth Parameter Registration</a>
+</h1>
 <p id="rfc.section.8.7.p.1">This specification registers the following parameters in the OAuth Parameters Registry</p>
-<p/>
+<p></p>
 
 <ul>
-  <li>Name: <samp>profile</samp></li>
-  <li>Parameter Usage Location: token request, token response</li>
-  <li>Change Controller: IESG</li>
-  <li>Reference: <a href="#paramProfile">Section 5.6.4.4</a> of [this document]</li>
+<li>Name: <samp>profile</samp>
+</li>
+<li>Parameter Usage Location: token request, token response</li>
+<li>Change Controller: IESG</li>
+<li>Reference: <a href="#paramProfile" class="xref">Section 5.6.4.4</a> of [this document]</li>
 </ul>
-<p/>
+<p></p>
 
 <ul>
-  <li>Name: <samp>cnf</samp></li>
-  <li>Parameter Usage Location: token request, token response</li>
-  <li>Change Controller: IESG</li>
-  <li>Reference: <a href="#paramCnf">Section 5.6.4.5</a> of [this document]</li>
+<li>Name: <samp>cnf</samp>
+</li>
+<li>Parameter Usage Location: token request, token response</li>
+<li>Change Controller: IESG</li>
+<li>Reference: <a href="#paramCnf" class="xref">Section 5.6.4.5</a> of [this document]</li>
 </ul>
-<p/>
+<p></p>
 
 <ul>
-  <li>Name: <samp>rs_cnf</samp></li>
-  <li>Parameter Usage Location: token response</li>
-  <li>Change Controller: IESG</li>
-  <li>Reference: <a href="#paramCnf">Section 5.6.4.5</a> of [this document]</li>
+<li>Name: <samp>rs_cnf</samp>
+</li>
+<li>Parameter Usage Location: token response</li>
+<li>Change Controller: IESG</li>
+<li>Reference: <a href="#paramCnf" class="xref">Section 5.6.4.5</a> of [this document]</li>
 </ul>
-<h1 id="rfc.section.8.8"><a href="#rfc.section.8.8">8.8.</a> <a href="#IANAOAuthParameterMappingsRegistry" id="IANAOAuthParameterMappingsRegistry">OAuth CBOR Parameter Mappings Registry</a></h1>
+<h1 id="rfc.section.8.8">
+<a href="#rfc.section.8.8">8.8.</a> <a href="#IANAOAuthParameterMappingsRegistry" id="IANAOAuthParameterMappingsRegistry">OAuth CBOR Parameter Mappings Registry</a>
+</h1>
 <p id="rfc.section.8.8.p.1">A new registry will be requested from IANA, entitled "Token Endpoint CBOR Mappings Registry".  The registry is to be created as Expert Review Required.</p>
 <p id="rfc.section.8.8.p.2">The columns of this table are: </p>
 
 <dl>
-  <dt>Name</dt>
-  <dd style="margin-left: 8">The OAuth Parameter name, refers to the name in the OAuth parameter registry e.g., "client_id".</dd>
-  <dt>CBOR Key</dt>
-  <dd style="margin-left: 8">The unsigned integer value abbreviating this parameter.  Registration in the table is based on the value of the mapping requested.  Integer values between 1 and 255 are designated as Standards Track Document required.  Integer values from 256 to 65535 are designated as Specification Required.  Integer values greater than 65535 are designated as private use.</dd>
-  <dt>Value Type</dt>
-  <dd style="margin-left: 8">The allowable CBOR data types for values of this parameter.</dd>
-  <dt>Reference</dt>
-  <dd style="margin-left: 8">This contains a pointer to the public specification of the grant type abbreviation, if one exists.</dd>
+<dt>Name</dt>
+<dd style="margin-left: 8">The OAuth Parameter name, refers to the name in the OAuth parameter registry e.g., "client_id".</dd>
+<dt>CBOR Key</dt>
+<dd style="margin-left: 8">The unsigned integer value abbreviating this parameter.  Registration in the table is based on the value of the mapping requested.  Integer values between 1 and 255 are designated as Standards Track Document required.  Integer values from 256 to 65535 are designated as Specification Required.  Integer values greater than 65535 are designated as private use.</dd>
+<dt>Value Type</dt>
+<dd style="margin-left: 8">The allowable CBOR data types for values of this parameter.</dd>
+<dt>Reference</dt>
+<dd style="margin-left: 8">This contains a pointer to the public specification of the grant type abbreviation, if one exists.</dd>
 </dl>
-<p id="rfc.section.8.8.p.3">This registry will be initially populated by the values in <a href="#fig:cborTokenParameters">Figure 12</a>. The Reference column for all of these entries will be this document.</p>
-<p id="rfc.section.8.8.p.4">Note that these mappings intentionally coincide with the CWT claim name mappings from <a href="#I-D.ietf-ace-cbor-web-token">[I-D.ietf-ace-cbor-web-token]</a>.</p>
-<h1 id="rfc.section.8.9"><a href="#rfc.section.8.9">8.9.</a> <a href="#IANAOAuthIntrospectionResponseParameterRegistration" id="IANAOAuthIntrospectionResponseParameterRegistration">OAuth Introspection Response Parameter Registration</a></h1>
+<p id="rfc.section.8.8.p.3">This registry will be initially populated by the values in <a href="#fig:cborTokenParameters" class="xref">Figure 12</a>. The Reference column for all of these entries will be this document.</p>
+<p id="rfc.section.8.8.p.4">Note that these mappings intentionally coincide with the CWT claim name mappings from <a href="#I-D.ietf-ace-cbor-web-token" class="xref">[I-D.ietf-ace-cbor-web-token]</a>.</p>
+<h1 id="rfc.section.8.9">
+<a href="#rfc.section.8.9">8.9.</a> <a href="#IANAOAuthIntrospectionResponseParameterRegistration" id="IANAOAuthIntrospectionResponseParameterRegistration">OAuth Introspection Response Parameter Registration</a>
+</h1>
 <p id="rfc.section.8.9.p.1">This specification registers the following parameters in the OAuth Token Introspection Response registry.</p>
-<p/>
+<p></p>
 
 <ul>
-  <li>Name: <samp>cnf</samp></li>
-  <li>Description: Key to prove the right to use an access token, formatted as specified in <a href="#I-D.ietf-ace-cwt-proof-of-possession">[I-D.ietf-ace-cwt-proof-of-possession]</a>. </li>
-  <li>Change Controller: IESG</li>
-  <li>Reference: <a href="#introAS2RS">Section 5.7.2</a> of [this document]</li>
+<li>Name: <samp>cnf</samp>
+</li>
+<li>Description: Key to prove the right to use an access token, formatted as specified in <a href="#I-D.ietf-ace-cwt-proof-of-possession" class="xref">[I-D.ietf-ace-cwt-proof-of-possession]</a>. </li>
+<li>Change Controller: IESG</li>
+<li>Reference: <a href="#introAS2RS" class="xref">Section 5.7.2</a> of [this document]</li>
 </ul>
 
 <p> </p>
-<p/>
+<p></p>
 
 <ul>
-  <li>Name: <samp>profile</samp></li>
-  <li>Description: The communication and communication security profile used between client and RS, as defined in ACE profiles.</li>
-  <li>Change Controller: IESG</li>
-  <li>Reference: <a href="#introAS2RS">Section 5.7.2</a> of [this document]</li>
+<li>Name: <samp>profile</samp>
+</li>
+<li>Description: The communication and communication security profile used between client and RS, as defined in ACE profiles.</li>
+<li>Change Controller: IESG</li>
+<li>Reference: <a href="#introAS2RS" class="xref">Section 5.7.2</a> of [this document]</li>
 </ul>
 
 <p> </p>
-<p/>
+<p></p>
 
 <ul>
-  <li>Name: <samp>client_token</samp></li>
-  <li>Description: Information that the RS MUST pass to the client e.g., about the proof-of-possession keys.</li>
-  <li>Change Controller: IESG</li>
-  <li>Reference: <a href="#introAS2RS">Section 5.7.2</a> of [this document]</li>
+<li>Name: <samp>client_token</samp>
+</li>
+<li>Description: Information that the RS MUST pass to the client e.g., about the proof-of-possession keys.</li>
+<li>Change Controller: IESG</li>
+<li>Reference: <a href="#introAS2RS" class="xref">Section 5.7.2</a> of [this document]</li>
 </ul>
 
 <p> </p>
-<h1 id="rfc.section.8.10"><a href="#rfc.section.8.10">8.10.</a> <a href="#IANAIntrospectionEndpointCBORMappingsRegistry" id="IANAIntrospectionEndpointCBORMappingsRegistry">Introspection Endpoint CBOR Mappings Registry</a></h1>
+<h1 id="rfc.section.8.10">
+<a href="#rfc.section.8.10">8.10.</a> <a href="#IANAIntrospectionEndpointCBORMappingsRegistry" id="IANAIntrospectionEndpointCBORMappingsRegistry">Introspection Endpoint CBOR Mappings Registry</a>
+</h1>
 <p id="rfc.section.8.10.p.1">A new registry will be requested from IANA, entitled "Introspection Endpoint CBOR Mappings Registry".  The registry is to be created as Expert Review Required.</p>
 <p id="rfc.section.8.10.p.2">The columns of this table are: </p>
 
 <dl>
-  <dt>Name</dt>
-  <dd style="margin-left: 8">The OAuth Parameter name, refers to the name in the OAuth parameter registry e.g., "client_id".</dd>
-  <dt>CBOR Key</dt>
-  <dd style="margin-left: 8">The unsigned integer value abbreviating this parameter.  Registration in the table is based on the value of the mapping requested.  Integer values between 1 and 255 are designated as Standards Track Document required.  Integer values from 256 to 65535 are designated as Specification Required.  Integer values greater than 65535 are designated as private use.</dd>
-  <dt>Value Type</dt>
-  <dd style="margin-left: 8">The allowable CBOR data types for values of this parameter.</dd>
-  <dt>Reference</dt>
-  <dd style="margin-left: 8">This contains a pointer to the public specification of the grant type abbreviation, if one exists.</dd>
+<dt>Name</dt>
+<dd style="margin-left: 8">The OAuth Parameter name, refers to the name in the OAuth parameter registry e.g., "client_id".</dd>
+<dt>CBOR Key</dt>
+<dd style="margin-left: 8">The unsigned integer value abbreviating this parameter.  Registration in the table is based on the value of the mapping requested.  Integer values between 1 and 255 are designated as Standards Track Document required.  Integer values from 256 to 65535 are designated as Specification Required.  Integer values greater than 65535 are designated as private use.</dd>
+<dt>Value Type</dt>
+<dd style="margin-left: 8">The allowable CBOR data types for values of this parameter.</dd>
+<dt>Reference</dt>
+<dd style="margin-left: 8">This contains a pointer to the public specification of the grant type abbreviation, if one exists.</dd>
 </dl>
-<p id="rfc.section.8.10.p.3">This registry will be initially populated by the values in <a href="#fig:cborIntrospectionParameters">Figure 16</a>. The Reference column for all of these entries will be this document.</p>
-<h1 id="rfc.section.8.11"><a href="#rfc.section.8.11">8.11.</a> <a href="#IANAJWTClaims" id="IANAJWTClaims">JSON Web Token Claims</a></h1>
+<p id="rfc.section.8.10.p.3">This registry will be initially populated by the values in <a href="#fig:cborIntrospectionParameters" class="xref">Figure 16</a>. The Reference column for all of these entries will be this document.</p>
+<h1 id="rfc.section.8.11">
+<a href="#rfc.section.8.11">8.11.</a> <a href="#IANAJWTClaims" id="IANAJWTClaims">JSON Web Token Claims</a>
+</h1>
 <p id="rfc.section.8.11.p.1">This specification registers the following new claims in the JSON Web Token (JWT) registry of JSON Web Token Claims:</p>
-<p/>
+<p></p>
 
 <ul>
-  <li>Claim Name: <samp>scope</samp></li>
-  <li>Claim Description: The scope of an access token as defined in <a href="#RFC6749">[RFC6749]</a>.</li>
-  <li>Change Controller: IESG</li>
-  <li>Reference: <a href="#accessToken">Section 5.8</a> of [this document]</li>
+<li>Claim Name: <samp>scope</samp>
+</li>
+<li>Claim Description: The scope of an access token as defined in <a href="#RFC6749" class="xref">[RFC6749]</a>.</li>
+<li>Change Controller: IESG</li>
+<li>Reference: <a href="#accessToken" class="xref">Section 5.8</a> of [this document]</li>
 </ul>
-<h1 id="rfc.section.8.12"><a href="#rfc.section.8.12">8.12.</a> <a href="#IANACWTClaims" id="IANACWTClaims">CBOR Web Token Claims</a></h1>
+<h1 id="rfc.section.8.12">
+<a href="#rfc.section.8.12">8.12.</a> <a href="#IANACWTClaims" id="IANACWTClaims">CBOR Web Token Claims</a>
+</h1>
 <p id="rfc.section.8.12.p.1">This specification registers the following new claims in the CBOR Web Token (CWT) registry of CBOR Web Token Claim:s</p>
-<p/>
+<p></p>
 
 <ul>
-  <li>Claim Name: <samp>scope</samp></li>
-  <li>Claim Description: The scope of an access token as defined in <a href="#RFC6749">[RFC6749]</a>.</li>
-  <li>JWT Claim Name: N/A</li>
-  <li>Claim Key: 12</li>
-  <li>Claim Value Type(s): 0 (uint), 2 (byte string), 3 (text string)</li>
-  <li>Change Controller: IESG</li>
-  <li>Specification Document(s): <a href="#accessToken">Section 5.8</a> of [this document]</li>
+<li>Claim Name: <samp>scope</samp>
+</li>
+<li>Claim Description: The scope of an access token as defined in <a href="#RFC6749" class="xref">[RFC6749]</a>.</li>
+<li>JWT Claim Name: N/A</li>
+<li>Claim Key: 12</li>
+<li>Claim Value Type(s): 0 (uint), 2 (byte string), 3 (text string)</li>
+<li>Change Controller: IESG</li>
+<li>Specification Document(s): <a href="#accessToken" class="xref">Section 5.8</a> of [this document]</li>
 </ul>
-<h1 id="rfc.section.8.13"><a href="#rfc.section.8.13">8.13.</a> <a href="#CoAPOptionNumberRegistration" id="CoAPOptionNumberRegistration">CoAP Option Number Registration</a></h1>
-<p id="rfc.section.8.13.p.1">This section registers the "Access-Token" CoAP Option Number in the "CoRE Parameters" sub-registry "CoAP Option Numbers" in the manner described in <a href="#RFC7252">[RFC7252]</a>.  </p>
-<p/>
+<h1 id="rfc.section.8.13">
+<a href="#rfc.section.8.13">8.13.</a> <a href="#CoAPOptionNumberRegistration" id="CoAPOptionNumberRegistration">CoAP Option Number Registration</a>
+</h1>
+<p id="rfc.section.8.13.p.1">This section registers the "Access-Token" CoAP Option Number in the "CoRE Parameters" sub-registry "CoAP Option Numbers" in the manner described in <a href="#RFC7252" class="xref">[RFC7252]</a>.  </p>
+<p></p>
 
 <ul>
-  <li>Name: <samp>Access-Token</samp></li>
-  <li>Number: TBD</li>
-  <li>Reference: [this document].</li>
-  <li>Meaning in Request: Contains an Access Token according to [this document] containing access permissions of the client.  </li>
-  <li>Meaning in Response: Not used in response.</li>
-  <li>Safe-to-Forward: Yes</li>
-  <li>Format: Based on the observer the format is perceived differently.  Opaque data to the client and CWT or reference token to the RS.  </li>
-  <li>Length: Less than 255 bytes</li>
+<li>Name: <samp>Access-Token</samp>
+</li>
+<li>Number: TBD</li>
+<li>Reference: [this document].</li>
+<li>Meaning in Request: Contains an Access Token according to [this document] containing access permissions of the client.  </li>
+<li>Meaning in Response: Not used in response.</li>
+<li>Safe-to-Forward: Yes</li>
+<li>Format: Based on the observer the format is perceived differently.  Opaque data to the client and CWT or reference token to the RS.  </li>
+<li>Length: Less than 255 bytes</li>
 </ul>
-<h1 id="rfc.section.9"><a href="#rfc.section.9">9.</a> <a href="#Acknowledgments" id="Acknowledgments">Acknowledgments</a></h1>
+<h1 id="rfc.section.9">
+<a href="#rfc.section.9">9.</a> <a href="#Acknowledgments" id="Acknowledgments">Acknowledgments</a>
+</h1>
 <p id="rfc.section.9.p.1">This document is a product of the ACE working group of the IETF.</p>
 <p id="rfc.section.9.p.2">Thanks to Eve Maler for her contributions to the use of OAuth 2.0 and UMA in IoT scenarios, Robert Taylor for his discussion input, and Malisa Vucinic for his input on the predecessors of this proposal.</p>
 <p id="rfc.section.9.p.3">Thanks to the authors of draft-ietf-oauth-pop-key-distribution, from where large parts of the security considerations where copied.</p>
-<p id="rfc.section.9.p.4">Thanks to Stefanie Gerdes, Olaf Bergmann, and Carsten Bormann for contributing their work on AS discovery from draft-gerdes-ace-dcaf-authorize (see <a href="#asDiscovery">Section 5.1</a>).</p>
+<p id="rfc.section.9.p.4">Thanks to Stefanie Gerdes, Olaf Bergmann, and Carsten Bormann for contributing their work on AS discovery from draft-gerdes-ace-dcaf-authorize (see <a href="#asDiscovery" class="xref">Section 5.1</a>).</p>
 <p id="rfc.section.9.p.5">Ludwig Seitz and Goeran Selander worked on this document as part of the CelticPlus project CyberWI, with funding from Vinnova.</p>
-<h1 id="rfc.references"><a href="#rfc.references">10.</a> References</h1>
-<h1 id="rfc.references.1"><a href="#rfc.references.1">10.1.</a> Normative References</h1>
-<table>
-  <tbody>
-    <tr>
-      <td class="reference">
-        <b id="I-D.ietf-ace-cbor-web-token">[I-D.ietf-ace-cbor-web-token]</b>
-      </td>
-      <td class="top"><a>Jones, M.</a>, <a>Wahlstroem, E.</a>, <a>Erdtman, S.</a> and <a>H. Tschofenig</a>, "<a href="http://tools.ietf.org/html/draft-ietf-ace-cbor-web-token-09">CBOR Web Token (CWT)</a>", Internet-Draft draft-ietf-ace-cbor-web-token-09, October 2017.</td>
-    </tr>
-    <tr>
-      <td class="reference">
-        <b id="I-D.ietf-ace-cwt-proof-of-possession">[I-D.ietf-ace-cwt-proof-of-possession]</b>
-      </td>
-      <td class="top"><a>Jones, M.</a>, <a>Seitz, L.</a>, <a>Selander, G.</a>, <a>Wahlstroem, E.</a>, <a>Erdtman, S.</a> and <a>H. Tschofenig</a>, "<a href="http://tools.ietf.org/html/draft-ietf-ace-cwt-proof-of-possession-01">Proof-of-Possession Key Semantics for CBOR Web Tokens (CWTs)</a>", Internet-Draft draft-ietf-ace-cwt-proof-of-possession-01, October 2017.</td>
-    </tr>
-    <tr>
-      <td class="reference">
-        <b id="RFC2119">[RFC2119]</b>
-      </td>
-      <td class="top"><a>Bradner, S.</a>, "<a href="http://tools.ietf.org/html/rfc2119">Key words for use in RFCs to Indicate Requirement Levels</a>", BCP 14, RFC 2119, DOI 10.17487/RFC2119, March 1997.</td>
-    </tr>
-    <tr>
-      <td class="reference">
-        <b id="RFC3986">[RFC3986]</b>
-      </td>
-      <td class="top"><a>Berners-Lee, T.</a>, <a>Fielding, R.</a> and <a>L. Masinter</a>, "<a href="http://tools.ietf.org/html/rfc3986">Uniform Resource Identifier (URI): Generic Syntax</a>", STD 66, RFC 3986, DOI 10.17487/RFC3986, January 2005.</td>
-    </tr>
-    <tr>
-      <td class="reference">
-        <b id="RFC6347">[RFC6347]</b>
-      </td>
-      <td class="top"><a>Rescorla, E.</a> and <a>N. Modadugu</a>, "<a href="http://tools.ietf.org/html/rfc6347">Datagram Transport Layer Security Version 1.2</a>", RFC 6347, DOI 10.17487/RFC6347, January 2012.</td>
-    </tr>
-    <tr>
-      <td class="reference">
-        <b id="RFC7252">[RFC7252]</b>
-      </td>
-      <td class="top"><a>Shelby, Z.</a>, <a>Hartke, K.</a> and <a>C. Bormann</a>, "<a href="http://tools.ietf.org/html/rfc7252">The Constrained Application Protocol (CoAP)</a>", RFC 7252, DOI 10.17487/RFC7252, June 2014.</td>
-    </tr>
-    <tr>
-      <td class="reference">
-        <b id="RFC7662">[RFC7662]</b>
-      </td>
-      <td class="top"><a>Richer, J.</a>, "<a href="http://tools.ietf.org/html/rfc7662">OAuth 2.0 Token Introspection</a>", RFC 7662, DOI 10.17487/RFC7662, October 2015.</td>
-    </tr>
-    <tr>
-      <td class="reference">
-        <b id="RFC8152">[RFC8152]</b>
-      </td>
-      <td class="top"><a>Schaad, J.</a>, "<a href="http://tools.ietf.org/html/rfc8152">CBOR Object Signing and Encryption (COSE)</a>", RFC 8152, DOI 10.17487/RFC8152, July 2017.</td>
-    </tr>
-  </tbody>
-</table>
-<h1 id="rfc.references.2"><a href="#rfc.references.2">10.2.</a> Informative References</h1>
-<table>
-  <tbody>
-    <tr>
-      <td class="reference">
-        <b id="I-D.erdtman-ace-rpcc">[I-D.erdtman-ace-rpcc]</b>
-      </td>
-      <td class="top"><a>Seitz, L.</a> and <a>S. Erdtman</a>, "<a href="http://tools.ietf.org/html/draft-erdtman-ace-rpcc-02">Raw-Public-Key and Pre-Shared-Key as OAuth client credentials</a>", Internet-Draft draft-erdtman-ace-rpcc-02, October 2017.</td>
-    </tr>
-    <tr>
-      <td class="reference">
-        <b id="I-D.ietf-ace-actors">[I-D.ietf-ace-actors]</b>
-      </td>
-      <td class="top"><a>Gerdes, S.</a>, <a>Seitz, L.</a>, <a>Selander, G.</a> and <a>C. Bormann</a>, "<a href="http://tools.ietf.org/html/draft-ietf-ace-actors-06">An architecture for authorization in constrained environments</a>", Internet-Draft draft-ietf-ace-actors-06, November 2017.</td>
-    </tr>
-    <tr>
-      <td class="reference">
-        <b id="I-D.ietf-core-object-security">[I-D.ietf-core-object-security]</b>
-      </td>
-      <td class="top"><a>Selander, G.</a>, <a>Mattsson, J.</a>, <a>Palombini, F.</a> and <a>L. Seitz</a>, "<a href="http://tools.ietf.org/html/draft-ietf-core-object-security-06">Object Security for Constrained RESTful Environments (OSCORE)</a>", Internet-Draft draft-ietf-core-object-security-06, October 2017.</td>
-    </tr>
-    <tr>
-      <td class="reference">
-        <b id="I-D.ietf-core-resource-directory">[I-D.ietf-core-resource-directory]</b>
-      </td>
-      <td class="top"><a>Shelby, Z.</a>, <a>Koster, M.</a>, <a>Bormann, C.</a>, <a>Stok, P.</a> and <a>C. Amsuess</a>, "<a href="http://tools.ietf.org/html/draft-ietf-core-resource-directory-12">CoRE Resource Directory</a>", Internet-Draft draft-ietf-core-resource-directory-12, October 2017.</td>
-    </tr>
-    <tr>
-      <td class="reference">
-        <b id="I-D.ietf-oauth-device-flow">[I-D.ietf-oauth-device-flow]</b>
-      </td>
-      <td class="top"><a>Denniss, W.</a>, <a>Bradley, J.</a>, <a>Jones, M.</a> and <a>H. Tschofenig</a>, "<a href="http://tools.ietf.org/html/draft-ietf-oauth-device-flow-07">OAuth 2.0 Device Flow for Browserless and Input Constrained Devices</a>", Internet-Draft draft-ietf-oauth-device-flow-07, October 2017.</td>
-    </tr>
-    <tr>
-      <td class="reference">
-        <b id="I-D.ietf-oauth-discovery">[I-D.ietf-oauth-discovery]</b>
-      </td>
-      <td class="top"><a>Jones, M.</a>, <a>Sakimura, N.</a> and <a>J. Bradley</a>, "<a href="http://tools.ietf.org/html/draft-ietf-oauth-discovery-07">OAuth 2.0 Authorization Server Metadata</a>", Internet-Draft draft-ietf-oauth-discovery-07, September 2017.</td>
-    </tr>
-    <tr>
-      <td class="reference">
-        <b id="I-D.ietf-oauth-native-apps">[I-D.ietf-oauth-native-apps]</b>
-      </td>
-      <td class="top"><a>Denniss, W.</a> and <a>J. Bradley</a>, "<a href="http://tools.ietf.org/html/draft-ietf-oauth-native-apps-12">OAuth 2.0 for Native Apps</a>", Internet-Draft draft-ietf-oauth-native-apps-12, June 2017.</td>
-    </tr>
-    <tr>
-      <td class="reference">
-        <b id="Margi10impact">[Margi10impact]</b>
-      </td>
-      <td class="top"><a>Margi, C.</a>, <a>de Oliveira, B.</a>, <a>de Sousa, G.</a>, <a>Simplicio Jr, M.</a>, <a>Barreto, P.</a>, <a>Carvalho, T.</a>, <a>Naeslund, M.</a> and <a>R. Gold</a>, "<a>Impact of Operating Systems on Wireless Sensor Networks (Security) Applications and Testbeds</a>", Proceedings of the 19th International Conference on Computer Communications and Networks (ICCCN), 2010 August.</td>
-    </tr>
-    <tr>
-      <td class="reference">
-        <b id="RFC4949">[RFC4949]</b>
-      </td>
-      <td class="top"><a>Shirey, R.</a>, "<a href="http://tools.ietf.org/html/rfc4949">Internet Security Glossary, Version 2</a>", FYI 36, RFC 4949, DOI 10.17487/RFC4949, August 2007.</td>
-    </tr>
-    <tr>
-      <td class="reference">
-        <b id="RFC5246">[RFC5246]</b>
-      </td>
-      <td class="top"><a>Dierks, T.</a> and <a>E. Rescorla</a>, "<a href="http://tools.ietf.org/html/rfc5246">The Transport Layer Security (TLS) Protocol Version 1.2</a>", RFC 5246, DOI 10.17487/RFC5246, August 2008.</td>
-    </tr>
-    <tr>
-      <td class="reference">
-        <b id="RFC6690">[RFC6690]</b>
-      </td>
-      <td class="top"><a>Shelby, Z.</a>, "<a href="http://tools.ietf.org/html/rfc6690">Constrained RESTful Environments (CoRE) Link Format</a>", RFC 6690, DOI 10.17487/RFC6690, August 2012.</td>
-    </tr>
-    <tr>
-      <td class="reference">
-        <b id="RFC6749">[RFC6749]</b>
-      </td>
-      <td class="top"><a>Hardt, D.</a>, "<a href="http://tools.ietf.org/html/rfc6749">The OAuth 2.0 Authorization Framework</a>", RFC 6749, DOI 10.17487/RFC6749, October 2012.</td>
-    </tr>
-    <tr>
-      <td class="reference">
-        <b id="RFC6819">[RFC6819]</b>
-      </td>
-      <td class="top"><a>Lodderstedt, T.</a>, <a>McGloin, M.</a> and <a>P. Hunt</a>, "<a href="http://tools.ietf.org/html/rfc6819">OAuth 2.0 Threat Model and Security Considerations</a>", RFC 6819, DOI 10.17487/RFC6819, January 2013.</td>
-    </tr>
-    <tr>
-      <td class="reference">
-        <b id="RFC7049">[RFC7049]</b>
-      </td>
-      <td class="top"><a>Bormann, C.</a> and <a>P. Hoffman</a>, "<a href="http://tools.ietf.org/html/rfc7049">Concise Binary Object Representation (CBOR)</a>", RFC 7049, DOI 10.17487/RFC7049, October 2013.</td>
-    </tr>
-    <tr>
-      <td class="reference">
-        <b id="RFC7159">[RFC7159]</b>
-      </td>
-      <td class="top"><a>Bray, T.</a>, "<a href="http://tools.ietf.org/html/rfc7159">The JavaScript Object Notation (JSON) Data Interchange Format</a>", RFC 7159, DOI 10.17487/RFC7159, March 2014.</td>
-    </tr>
-    <tr>
-      <td class="reference">
-        <b id="RFC7228">[RFC7228]</b>
-      </td>
-      <td class="top"><a>Bormann, C.</a>, <a>Ersue, M.</a> and <a>A. Keranen</a>, "<a href="http://tools.ietf.org/html/rfc7228">Terminology for Constrained-Node Networks</a>", RFC 7228, DOI 10.17487/RFC7228, May 2014.</td>
-    </tr>
-    <tr>
-      <td class="reference">
-        <b id="RFC7231">[RFC7231]</b>
-      </td>
-      <td class="top"><a>Fielding, R.</a> and <a>J. Reschke</a>, "<a href="http://tools.ietf.org/html/rfc7231">Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content</a>", RFC 7231, DOI 10.17487/RFC7231, June 2014.</td>
-    </tr>
-    <tr>
-      <td class="reference">
-        <b id="RFC7519">[RFC7519]</b>
-      </td>
-      <td class="top"><a>Jones, M.</a>, <a>Bradley, J.</a> and <a>N. Sakimura</a>, "<a href="http://tools.ietf.org/html/rfc7519">JSON Web Token (JWT)</a>", RFC 7519, DOI 10.17487/RFC7519, May 2015.</td>
-    </tr>
-    <tr>
-      <td class="reference">
-        <b id="RFC7521">[RFC7521]</b>
-      </td>
-      <td class="top"><a>Campbell, B.</a>, <a>Mortimore, C.</a>, <a>Jones, M.</a> and <a>Y. Goland</a>, "<a href="http://tools.ietf.org/html/rfc7521">Assertion Framework for OAuth 2.0 Client Authentication and Authorization Grants</a>", RFC 7521, DOI 10.17487/RFC7521, May 2015.</td>
-    </tr>
-    <tr>
-      <td class="reference">
-        <b id="RFC7591">[RFC7591]</b>
-      </td>
-      <td class="top"><a>Richer, J.</a>, <a>Jones, M.</a>, <a>Bradley, J.</a>, <a>Machulak, M.</a> and <a>P. Hunt</a>, "<a href="http://tools.ietf.org/html/rfc7591">OAuth 2.0 Dynamic Client Registration Protocol</a>", RFC 7591, DOI 10.17487/RFC7591, July 2015.</td>
-    </tr>
-    <tr>
-      <td class="reference">
-        <b id="RFC7641">[RFC7641]</b>
-      </td>
-      <td class="top"><a>Hartke, K.</a>, "<a href="http://tools.ietf.org/html/rfc7641">Observing Resources in the Constrained Application Protocol (CoAP)</a>", RFC 7641, DOI 10.17487/RFC7641, September 2015.</td>
-    </tr>
-    <tr>
-      <td class="reference">
-        <b id="RFC7744">[RFC7744]</b>
-      </td>
-      <td class="top"><a>Seitz, L.</a>, <a>Gerdes, S.</a>, <a>Selander, G.</a>, <a>Mani, M.</a> and <a>S. Kumar</a>, "<a href="http://tools.ietf.org/html/rfc7744">Use Cases for Authentication and Authorization in Constrained Environments</a>", RFC 7744, DOI 10.17487/RFC7744, January 2016.</td>
-    </tr>
-    <tr>
-      <td class="reference">
-        <b id="RFC7959">[RFC7959]</b>
-      </td>
-      <td class="top"><a>Bormann, C.</a> and <a>Z. Shelby</a>, "<a href="http://tools.ietf.org/html/rfc7959">Block-Wise Transfers in the Constrained Application Protocol (CoAP)</a>", RFC 7959, DOI 10.17487/RFC7959, August 2016.</td>
-    </tr>
-  </tbody>
-</table>
-<h1 id="rfc.appendix.A"><a href="#rfc.appendix.A">Appendix A.</a> <a href="#constraints" id="constraints">Design Justification</a></h1>
-<p id="rfc.section.A.p.1">This section provides further insight into the design decisions of the solution documented in this document.  <a href="#overview">Section 3</a> lists several building blocks and briefly summarizes their importance.  The justification for offering some of those building blocks, as opposed to using OAuth 2.0 as is, is given below.</p>
+<h1 id="rfc.references">
+<a href="#rfc.references">10.</a> References</h1>
+<h1 id="rfc.references.1">
+<a href="#rfc.references.1">10.1.</a> Normative References</h1>
+<table><tbody>
+<tr>
+<td class="reference"><b id="I-D.ietf-ace-cbor-web-token">[I-D.ietf-ace-cbor-web-token]</b></td>
+<td class="top">
+<a>Jones, M.</a>, <a>Wahlstroem, E.</a>, <a>Erdtman, S.</a> and <a>H. Tschofenig</a>, "<a href="https://tools.ietf.org/html/draft-ietf-ace-cbor-web-token-10">CBOR Web Token (CWT)</a>", Internet-Draft draft-ietf-ace-cbor-web-token-10, December 2017.</td>
+</tr>
+<tr>
+<td class="reference"><b id="I-D.ietf-ace-cwt-proof-of-possession">[I-D.ietf-ace-cwt-proof-of-possession]</b></td>
+<td class="top">
+<a>Jones, M.</a>, <a>Seitz, L.</a>, <a>Selander, G.</a>, <a>Wahlstroem, E.</a>, <a>Erdtman, S.</a> and <a>H. Tschofenig</a>, "<a href="https://tools.ietf.org/html/draft-ietf-ace-cwt-proof-of-possession-01">Proof-of-Possession Key Semantics for CBOR Web Tokens (CWTs)</a>", Internet-Draft draft-ietf-ace-cwt-proof-of-possession-01, October 2017.</td>
+</tr>
+<tr>
+<td class="reference"><b id="RFC2119">[RFC2119]</b></td>
+<td class="top">
+<a>Bradner, S.</a>, "<a href="https://tools.ietf.org/html/rfc2119">Key words for use in RFCs to Indicate Requirement Levels</a>", BCP 14, RFC 2119, DOI 10.17487/RFC2119, March 1997.</td>
+</tr>
+<tr>
+<td class="reference"><b id="RFC3986">[RFC3986]</b></td>
+<td class="top">
+<a>Berners-Lee, T.</a>, <a>Fielding, R.</a> and <a>L. Masinter</a>, "<a href="https://tools.ietf.org/html/rfc3986">Uniform Resource Identifier (URI): Generic Syntax</a>", STD 66, RFC 3986, DOI 10.17487/RFC3986, January 2005.</td>
+</tr>
+<tr>
+<td class="reference"><b id="RFC6347">[RFC6347]</b></td>
+<td class="top">
+<a>Rescorla, E.</a> and <a>N. Modadugu</a>, "<a href="https://tools.ietf.org/html/rfc6347">Datagram Transport Layer Security Version 1.2</a>", RFC 6347, DOI 10.17487/RFC6347, January 2012.</td>
+</tr>
+<tr>
+<td class="reference"><b id="RFC7252">[RFC7252]</b></td>
+<td class="top">
+<a>Shelby, Z.</a>, <a>Hartke, K.</a> and <a>C. Bormann</a>, "<a href="https://tools.ietf.org/html/rfc7252">The Constrained Application Protocol (CoAP)</a>", RFC 7252, DOI 10.17487/RFC7252, June 2014.</td>
+</tr>
+<tr>
+<td class="reference"><b id="RFC7662">[RFC7662]</b></td>
+<td class="top">
+<a>Richer, J.</a>, "<a href="https://tools.ietf.org/html/rfc7662">OAuth 2.0 Token Introspection</a>", RFC 7662, DOI 10.17487/RFC7662, October 2015.</td>
+</tr>
+<tr>
+<td class="reference"><b id="RFC8152">[RFC8152]</b></td>
+<td class="top">
+<a>Schaad, J.</a>, "<a href="https://tools.ietf.org/html/rfc8152">CBOR Object Signing and Encryption (COSE)</a>", RFC 8152, DOI 10.17487/RFC8152, July 2017.</td>
+</tr>
+</tbody></table>
+<h1 id="rfc.references.2">
+<a href="#rfc.references.2">10.2.</a> Informative References</h1>
+<table><tbody>
+<tr>
+<td class="reference"><b id="I-D.erdtman-ace-rpcc">[I-D.erdtman-ace-rpcc]</b></td>
+<td class="top">
+<a>Seitz, L.</a> and <a>S. Erdtman</a>, "<a href="https://tools.ietf.org/html/draft-erdtman-ace-rpcc-02">Raw-Public-Key and Pre-Shared-Key as OAuth client credentials</a>", Internet-Draft draft-erdtman-ace-rpcc-02, October 2017.</td>
+</tr>
+<tr>
+<td class="reference"><b id="I-D.ietf-ace-actors">[I-D.ietf-ace-actors]</b></td>
+<td class="top">
+<a>Gerdes, S.</a>, <a>Seitz, L.</a>, <a>Selander, G.</a> and <a>C. Bormann</a>, "<a href="https://tools.ietf.org/html/draft-ietf-ace-actors-06">An architecture for authorization in constrained environments</a>", Internet-Draft draft-ietf-ace-actors-06, November 2017.</td>
+</tr>
+<tr>
+<td class="reference"><b id="I-D.ietf-core-object-security">[I-D.ietf-core-object-security]</b></td>
+<td class="top">
+<a>Selander, G.</a>, <a>Mattsson, J.</a>, <a>Palombini, F.</a> and <a>L. Seitz</a>, "<a href="https://tools.ietf.org/html/draft-ietf-core-object-security-07">Object Security for Constrained RESTful Environments (OSCORE)</a>", Internet-Draft draft-ietf-core-object-security-07, November 2017.</td>
+</tr>
+<tr>
+<td class="reference"><b id="I-D.ietf-core-resource-directory">[I-D.ietf-core-resource-directory]</b></td>
+<td class="top">
+<a>Shelby, Z.</a>, <a>Koster, M.</a>, <a>Bormann, C.</a>, <a>Stok, P.</a> and <a>C. Amsuess</a>, "<a href="https://tools.ietf.org/html/draft-ietf-core-resource-directory-12">CoRE Resource Directory</a>", Internet-Draft draft-ietf-core-resource-directory-12, October 2017.</td>
+</tr>
+<tr>
+<td class="reference"><b id="I-D.ietf-oauth-device-flow">[I-D.ietf-oauth-device-flow]</b></td>
+<td class="top">
+<a>Denniss, W.</a>, <a>Bradley, J.</a>, <a>Jones, M.</a> and <a>H. Tschofenig</a>, "<a href="https://tools.ietf.org/html/draft-ietf-oauth-device-flow-07">OAuth 2.0 Device Flow for Browserless and Input Constrained Devices</a>", Internet-Draft draft-ietf-oauth-device-flow-07, October 2017.</td>
+</tr>
+<tr>
+<td class="reference"><b id="I-D.ietf-oauth-discovery">[I-D.ietf-oauth-discovery]</b></td>
+<td class="top">
+<a>Jones, M.</a>, <a>Sakimura, N.</a> and <a>J. Bradley</a>, "<a href="https://tools.ietf.org/html/draft-ietf-oauth-discovery-08">OAuth 2.0 Authorization Server Metadata</a>", Internet-Draft draft-ietf-oauth-discovery-08, November 2017.</td>
+</tr>
+<tr>
+<td class="reference"><b id="I-D.ietf-oauth-native-apps">[I-D.ietf-oauth-native-apps]</b></td>
+<td class="top">
+<a>Denniss, W.</a> and <a>J. Bradley</a>, "<a href="https://tools.ietf.org/html/draft-ietf-oauth-native-apps-12">OAuth 2.0 for Native Apps</a>", Internet-Draft draft-ietf-oauth-native-apps-12, June 2017.</td>
+</tr>
+<tr>
+<td class="reference"><b id="Margi10impact">[Margi10impact]</b></td>
+<td class="top">
+<a>Margi, C.</a>, <a>de Oliveira, B.</a>, <a>de Sousa, G.</a>, <a>Simplicio Jr, M.</a>, <a>Barreto, P.</a>, <a>Carvalho, T.</a>, <a>Naeslund, M.</a> and <a>R. Gold</a>, "<a>Impact of Operating Systems on Wireless Sensor Networks (Security) Applications and Testbeds</a>", Proceedings of the 19th International Conference on Computer Communications and Networks (ICCCN), 2010 August.</td>
+</tr>
+<tr>
+<td class="reference"><b id="RFC4949">[RFC4949]</b></td>
+<td class="top">
+<a>Shirey, R.</a>, "<a href="https://tools.ietf.org/html/rfc4949">Internet Security Glossary, Version 2</a>", FYI 36, RFC 4949, DOI 10.17487/RFC4949, August 2007.</td>
+</tr>
+<tr>
+<td class="reference"><b id="RFC5246">[RFC5246]</b></td>
+<td class="top">
+<a>Dierks, T.</a> and <a>E. Rescorla</a>, "<a href="https://tools.ietf.org/html/rfc5246">The Transport Layer Security (TLS) Protocol Version 1.2</a>", RFC 5246, DOI 10.17487/RFC5246, August 2008.</td>
+</tr>
+<tr>
+<td class="reference"><b id="RFC6690">[RFC6690]</b></td>
+<td class="top">
+<a>Shelby, Z.</a>, "<a href="https://tools.ietf.org/html/rfc6690">Constrained RESTful Environments (CoRE) Link Format</a>", RFC 6690, DOI 10.17487/RFC6690, August 2012.</td>
+</tr>
+<tr>
+<td class="reference"><b id="RFC6749">[RFC6749]</b></td>
+<td class="top">
+<a>Hardt, D.</a>, "<a href="https://tools.ietf.org/html/rfc6749">The OAuth 2.0 Authorization Framework</a>", RFC 6749, DOI 10.17487/RFC6749, October 2012.</td>
+</tr>
+<tr>
+<td class="reference"><b id="RFC6819">[RFC6819]</b></td>
+<td class="top">
+<a>Lodderstedt, T.</a>, <a>McGloin, M.</a> and <a>P. Hunt</a>, "<a href="https://tools.ietf.org/html/rfc6819">OAuth 2.0 Threat Model and Security Considerations</a>", RFC 6819, DOI 10.17487/RFC6819, January 2013.</td>
+</tr>
+<tr>
+<td class="reference"><b id="RFC7049">[RFC7049]</b></td>
+<td class="top">
+<a>Bormann, C.</a> and <a>P. Hoffman</a>, "<a href="https://tools.ietf.org/html/rfc7049">Concise Binary Object Representation (CBOR)</a>", RFC 7049, DOI 10.17487/RFC7049, October 2013.</td>
+</tr>
+<tr>
+<td class="reference"><b id="RFC7159">[RFC7159]</b></td>
+<td class="top">
+<a>Bray, T.</a>, "<a href="https://tools.ietf.org/html/rfc7159">The JavaScript Object Notation (JSON) Data Interchange Format</a>", RFC 7159, DOI 10.17487/RFC7159, March 2014.</td>
+</tr>
+<tr>
+<td class="reference"><b id="RFC7228">[RFC7228]</b></td>
+<td class="top">
+<a>Bormann, C.</a>, <a>Ersue, M.</a> and <a>A. Keranen</a>, "<a href="https://tools.ietf.org/html/rfc7228">Terminology for Constrained-Node Networks</a>", RFC 7228, DOI 10.17487/RFC7228, May 2014.</td>
+</tr>
+<tr>
+<td class="reference"><b id="RFC7231">[RFC7231]</b></td>
+<td class="top">
+<a>Fielding, R.</a> and <a>J. Reschke</a>, "<a href="https://tools.ietf.org/html/rfc7231">Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content</a>", RFC 7231, DOI 10.17487/RFC7231, June 2014.</td>
+</tr>
+<tr>
+<td class="reference"><b id="RFC7519">[RFC7519]</b></td>
+<td class="top">
+<a>Jones, M.</a>, <a>Bradley, J.</a> and <a>N. Sakimura</a>, "<a href="https://tools.ietf.org/html/rfc7519">JSON Web Token (JWT)</a>", RFC 7519, DOI 10.17487/RFC7519, May 2015.</td>
+</tr>
+<tr>
+<td class="reference"><b id="RFC7521">[RFC7521]</b></td>
+<td class="top">
+<a>Campbell, B.</a>, <a>Mortimore, C.</a>, <a>Jones, M.</a> and <a>Y. Goland</a>, "<a href="https://tools.ietf.org/html/rfc7521">Assertion Framework for OAuth 2.0 Client Authentication and Authorization Grants</a>", RFC 7521, DOI 10.17487/RFC7521, May 2015.</td>
+</tr>
+<tr>
+<td class="reference"><b id="RFC7591">[RFC7591]</b></td>
+<td class="top">
+<a>Richer, J.</a>, <a>Jones, M.</a>, <a>Bradley, J.</a>, <a>Machulak, M.</a> and <a>P. Hunt</a>, "<a href="https://tools.ietf.org/html/rfc7591">OAuth 2.0 Dynamic Client Registration Protocol</a>", RFC 7591, DOI 10.17487/RFC7591, July 2015.</td>
+</tr>
+<tr>
+<td class="reference"><b id="RFC7641">[RFC7641]</b></td>
+<td class="top">
+<a>Hartke, K.</a>, "<a href="https://tools.ietf.org/html/rfc7641">Observing Resources in the Constrained Application Protocol (CoAP)</a>", RFC 7641, DOI 10.17487/RFC7641, September 2015.</td>
+</tr>
+<tr>
+<td class="reference"><b id="RFC7744">[RFC7744]</b></td>
+<td class="top">
+<a>Seitz, L.</a>, <a>Gerdes, S.</a>, <a>Selander, G.</a>, <a>Mani, M.</a> and <a>S. Kumar</a>, "<a href="https://tools.ietf.org/html/rfc7744">Use Cases for Authentication and Authorization in Constrained Environments</a>", RFC 7744, DOI 10.17487/RFC7744, January 2016.</td>
+</tr>
+<tr>
+<td class="reference"><b id="RFC7959">[RFC7959]</b></td>
+<td class="top">
+<a>Bormann, C.</a> and <a>Z. Shelby</a>, "<a href="https://tools.ietf.org/html/rfc7959">Block-Wise Transfers in the Constrained Application Protocol (CoAP)</a>", RFC 7959, DOI 10.17487/RFC7959, August 2016.</td>
+</tr>
+</tbody></table>
+<h1 id="rfc.appendix.A">
+<a href="#rfc.appendix.A">Appendix A.</a> <a href="#constraints" id="constraints">Design Justification</a>
+</h1>
+<p id="rfc.section.A.p.1">This section provides further insight into the design decisions of the solution documented in this document.  <a href="#overview" class="xref">Section 3</a> lists several building blocks and briefly summarizes their importance.  The justification for offering some of those building blocks, as opposed to using OAuth 2.0 as is, is given below.</p>
 <p id="rfc.section.A.p.2">Common IoT constraints are: </p>
 
 <dl>
-  <dt>Low Power Radio:</dt>
-  <dd style="margin-left: 8"><br/><br/> Many IoT devices are equipped with a small battery which needs to last for a long time.  For many constrained wireless devices, the highest energy cost is associated to transmitting or receiving messages (roughly by a factor of 10 compared to e.g. AES) <a href="#Margi10impact">[Margi10impact]</a>.  It is therefore important to keep the total communication overhead low, including minimizing the number and size of messages sent and received, which has an impact of choice on the message format and protocol.  By using CoAP over UDP and CBOR encoded messages, some of these aspects are addressed.  Security protocols contribute to the communication overhead and can, in some cases, be optimized.  For example, authentication and key establishment may, in certain cases where security requirements allow, be replaced by provisioning of security context by a trusted third party, using transport or application layer security.  <br/> </dd>
-  <dt>Low CPU Speed:</dt>
-  <dd style="margin-left: 8"><br/><br/> Some IoT devices are equipped with processors that are significantly slower than those found in most current devices on the Internet.  This typically has implications on what timely cryptographic operations a device is capable of performing, which in turn impacts e.g., protocol latency.  Symmetric key cryptography may be used instead of the computationally more expensive public key cryptography where the security requirements so allows, but this may also require support for trusted third party assisted secret key establishment using transport or application layer security.  <br/></dd>
-  <dt>Small Amount of Memory:</dt>
-  <dd style="margin-left: 8"><br/><br/> Microcontrollers embedded in IoT devices are often equipped with small amount of RAM and flash memory, which places limitations what kind of processing can be performed and how much code can be put on those devices.  To reduce code size fewer and smaller protocol implementations can be put on the firmware of such a device.  In this case, CoAP may be used instead of HTTP,  symmetric key cryptography instead of public key cryptography, and CBOR instead of JSON.  Authentication and key establishment protocol, e.g., the DTLS handshake,  in comparison with assisted key establishment also has an impact on memory and code.<br/> </dd>
-  <dt>User Interface Limitations:</dt>
-  <dd style="margin-left: 8"><br/><br/> Protecting access to resources is both an important security as well as privacy feature.  End users and enterprise customers may not want to give access to the data collected by their IoT device or to functions it may offer to third parties.  Since the classical approach of requesting permissions from end users via a rich user interface does not work in many IoT deployment scenarios, these functions need to be delegated to user-controlled devices that are better suitable for such tasks, such as smart phones and tablets.  <br/><br/></dd>
-  <dt>Communication Constraints:</dt>
-  <dd style="margin-left: 8"><br/><br/> In certain constrained settings an IoT device may not be able to communicate with a given device at all times.  Devices may be sleeping, or just disconnected from the Internet because of general lack of connectivity in the area, for cost reasons, or for security reasons, e.g., to avoid an entry point for Denial-of-Service attacks.  <br/><br/> The communication interactions this framework builds upon (as shown graphically in <a href="#fig:protocolFlow">Figure 1</a>) may be accomplished using a variety of different protocols, and not all parts of the message flow are used in all applications due to the communication constraints.  Deployments making use of CoAP are expected, but not limited to, other protocols such as HTTP, HTTP/2 or other specific protocols, such as Bluetooth Smart communication, that do not necessarily use IP could also be used.  The latter raises the need for application layer security over the various interfaces.</dd>
+<dt>Low Power Radio:</dt>
+<dd style="margin-left: 8">
+<br><br> Many IoT devices are equipped with a small battery which needs to last for a long time.  For many constrained wireless devices, the highest energy cost is associated to transmitting or receiving messages (roughly by a factor of 10 compared to e.g. AES) <a href="#Margi10impact" class="xref">[Margi10impact]</a>.  It is therefore important to keep the total communication overhead low, including minimizing the number and size of messages sent and received, which has an impact of choice on the message format and protocol.  By using CoAP over UDP and CBOR encoded messages, some of these aspects are addressed.  Security protocols contribute to the communication overhead and can, in some cases, be optimized.  For example, authentication and key establishment may, in certain cases where security requirements allow, be replaced by provisioning of security context by a trusted third party, using transport or application layer security.  <br> </dd>
+<dt>Low CPU Speed:</dt>
+<dd style="margin-left: 8">
+<br><br> Some IoT devices are equipped with processors that are significantly slower than those found in most current devices on the Internet.  This typically has implications on what timely cryptographic operations a device is capable of performing, which in turn impacts e.g., protocol latency.  Symmetric key cryptography may be used instead of the computationally more expensive public key cryptography where the security requirements so allows, but this may also require support for trusted third party assisted secret key establishment using transport or application layer security.  <br>
+</dd>
+<dt>Small Amount of Memory:</dt>
+<dd style="margin-left: 8">
+<br><br> Microcontrollers embedded in IoT devices are often equipped with small amount of RAM and flash memory, which places limitations what kind of processing can be performed and how much code can be put on those devices.  To reduce code size fewer and smaller protocol implementations can be put on the firmware of such a device.  In this case, CoAP may be used instead of HTTP,  symmetric key cryptography instead of public key cryptography, and CBOR instead of JSON.  Authentication and key establishment protocol, e.g., the DTLS handshake,  in comparison with assisted key establishment also has an impact on memory and code.<br> </dd>
+<dt>User Interface Limitations:</dt>
+<dd style="margin-left: 8">
+<br><br> Protecting access to resources is both an important security as well as privacy feature.  End users and enterprise customers may not want to give access to the data collected by their IoT device or to functions it may offer to third parties.  Since the classical approach of requesting permissions from end users via a rich user interface does not work in many IoT deployment scenarios, these functions need to be delegated to user-controlled devices that are better suitable for such tasks, such as smart phones and tablets.  <br><br>
+</dd>
+<dt>Communication Constraints:</dt>
+<dd style="margin-left: 8">
+<br><br> In certain constrained settings an IoT device may not be able to communicate with a given device at all times.  Devices may be sleeping, or just disconnected from the Internet because of general lack of connectivity in the area, for cost reasons, or for security reasons, e.g., to avoid an entry point for Denial-of-Service attacks.  <br><br> The communication interactions this framework builds upon (as shown graphically in <a href="#fig:protocolFlow" class="xref">Figure 1</a>) may be accomplished using a variety of different protocols, and not all parts of the message flow are used in all applications due to the communication constraints.  Deployments making use of CoAP are expected, but not limited to, other protocols such as HTTP, HTTP/2 or other specific protocols, such as Bluetooth Smart communication, that do not necessarily use IP could also be used.  The latter raises the need for application layer security over the various interfaces.</dd>
 </dl>
 
 <p> </p>
 <p id="rfc.section.A.p.3">In the light of these constraints we have made the following design decisions: </p>
 
 <dl>
-  <dt>CBOR, COSE, CWT:</dt>
-  <dd style="margin-left: 8"><br/><br/> This framework REQUIRES the use of CBOR <a href="#RFC7049">[RFC7049]</a> as data format.  Where CBOR data needs to be protected, the use of COSE <a href="#RFC8152">[RFC8152]</a> is RECOMMENDED.  Furthermore where self-contained tokens are needed, this framework RECOMMENDS the use of CWT <a href="#I-D.ietf-ace-cbor-web-token">[I-D.ietf-ace-cbor-web-token]</a>.  These measures aim at reducing the size of messages sent over the wire, the RAM size of data objects that need to be kept in memory and the size of libraries that devices need to support.  <br/><br/></dd>
-  <dt>CoAP:</dt>
-  <dd style="margin-left: 8"><br/><br/> This framework RECOMMENDS the use of CoAP <a href="#RFC7252">[RFC7252]</a> instead of HTTP.  This does not preclude the use of other protocols specifically aimed at constrained devices, like e.g. Bluetooth Low energy (see <a href="#coap">Section 3.2</a>).  This aims again at reducing the size of messages sent over the wire, the RAM size of data objects that need to be kept in memory and the size of libraries that devices need to support.  <br/><br/></dd>
-  <dt>RS Information:</dt>
-  <dd style="margin-left: 8"><br/><br/> This framework defines the name "RS Information" for data concerning the RS that the AS returns to the client in an access token response (see  <a href="#tokenResponse">Section 5.6.2</a>).  This includes the "profile" and the "rs_cnf" parameters.  This aims at enabling scenarios, where a powerful client, supporting multiple profiles, needs to interact with a RS for which it does not know the supported profiles and the raw public key.  <br/><br/></dd>
-  <dt>Proof-of-Possession:</dt>
-  <dd style="margin-left: 8"><br/><br/> This framework makes use of proof-of-possession tokens, using the "cnf" claim <a href="#I-D.ietf-ace-cwt-proof-of-possession">[I-D.ietf-ace-cwt-proof-of-possession]</a>. A semantically and syntactically identical request and response parameter is defined for the token endpoint, to allow requesting and stating confirmation keys.  This aims at making token theft harder. Token theft is specifically relevant in constrained use cases, as communication often passes through middle-boxes, which could be able to steal bearer tokens and use them to gain unauthorized access.  <br/><br/> </dd>
-  <dt>Auth-Info endpoint:</dt>
-  <dd style="margin-left: 8"><br/><br/> This framework introduces a new way of providing access tokens to a RS by exposing a authz-info endpoint, to which access tokens can be POSTed.  This aims at reducing the size of the request message and the code complexity at the RS.  The size of the request message is problematic, since many constrained protocols have severe message size limitations at the physical layer (e.g. in the order of 100 bytes). This means that larger packets get fragmented, which in turn combines badly with the high rate of packet loss, and the need to retransmit the whole message if one packet gets lost.  Thus separating sending of the request and sending of the access tokens helps to reduce fragmentation.  <br/><br/></dd>
-  <dt>Client Credentials Grant:</dt>
-  <dd style="margin-left: 8"><br/><br/> This framework RECOMMENDS the use of the client credentials grant for machine-to-machine communication use cases, where manual intervention of the resource owner to produce a grant token is not feasible.  The intention is that the resource owner would instead pre-arrange authorization with the AS, based on the client's own credentials.  The client can the (without manual intervention) obtain access tokens from the AS.  <br/><br/></dd>
-  <dt>Introspection:</dt>
-  <dd style="margin-left: 8"><br/><br/> This framework RECOMMENDS the use of access token introspection in cases where the client is constrained in a way that it can not easily obtain new access tokens (i.e. it has connectivity issues that prevent it from communicating with the AS). In that case this framework RECOMMENDS the use of a long-term token, that could be a simple reference.  The RS is assumed to be able to communicate with the AS, and can therefore perform introspection, in order to learn the claims associated with the token reference.  The advantage of such an approach is that the resource owner can change the claims associated to the token reference without having to be in contact with the client, thus granting or revoking access rights.  <br/><br/></dd>
-  <dt>Client Token:</dt>
-  <dd style="margin-left: 8"><br/><br/> In cases where the client is constrained and does not have connectivity to the AS, and furthermore does not have a previous security relation to the RS that it needs to communicate with, this framework proposes the use of "client tokens".  A client token is a data object obtained from the AS by the RS, during access token introspection.  The RS passes the client token on to the client.  It contains information that allows the client to perform the proof of possession for its access token and to authenticate the RS (e.g. with it's public key).  </dd>
+<dt>CBOR, COSE, CWT:</dt>
+<dd style="margin-left: 8">
+<br><br> This framework REQUIRES the use of CBOR <a href="#RFC7049" class="xref">[RFC7049]</a> as data format.  Where CBOR data needs to be protected, the use of COSE <a href="#RFC8152" class="xref">[RFC8152]</a> is RECOMMENDED.  Furthermore where self-contained tokens are needed, this framework RECOMMENDS the use of CWT <a href="#I-D.ietf-ace-cbor-web-token" class="xref">[I-D.ietf-ace-cbor-web-token]</a>.  These measures aim at reducing the size of messages sent over the wire, the RAM size of data objects that need to be kept in memory and the size of libraries that devices need to support.  <br><br>
+</dd>
+<dt>CoAP:</dt>
+<dd style="margin-left: 8">
+<br><br> This framework RECOMMENDS the use of CoAP <a href="#RFC7252" class="xref">[RFC7252]</a> instead of HTTP.  This does not preclude the use of other protocols specifically aimed at constrained devices, like e.g. Bluetooth Low energy (see <a href="#coap" class="xref">Section 3.2</a>).  This aims again at reducing the size of messages sent over the wire, the RAM size of data objects that need to be kept in memory and the size of libraries that devices need to support.  <br><br>
+</dd>
+<dt>RS Information:</dt>
+<dd style="margin-left: 8">
+<br><br> This framework defines the name "RS Information" for data concerning the RS that the AS returns to the client in an access token response (see  <a href="#tokenResponse" class="xref">Section 5.6.2</a>).  This includes the "profile" and the "rs_cnf" parameters.  This aims at enabling scenarios, where a powerful client, supporting multiple profiles, needs to interact with a RS for which it does not know the supported profiles and the raw public key.  <br><br>
+</dd>
+<dt>Proof-of-Possession:</dt>
+<dd style="margin-left: 8">
+<br><br> This framework makes use of proof-of-possession tokens, using the "cnf" claim <a href="#I-D.ietf-ace-cwt-proof-of-possession" class="xref">[I-D.ietf-ace-cwt-proof-of-possession]</a>. A semantically and syntactically identical request and response parameter is defined for the token endpoint, to allow requesting and stating confirmation keys.  This aims at making token theft harder. Token theft is specifically relevant in constrained use cases, as communication often passes through middle-boxes, which could be able to steal bearer tokens and use them to gain unauthorized access.  <br><br> </dd>
+<dt>Auth-Info endpoint:</dt>
+<dd style="margin-left: 8">
+<br><br> This framework introduces a new way of providing access tokens to a RS by exposing a authz-info endpoint, to which access tokens can be POSTed.  This aims at reducing the size of the request message and the code complexity at the RS.  The size of the request message is problematic, since many constrained protocols have severe message size limitations at the physical layer (e.g. in the order of 100 bytes). This means that larger packets get fragmented, which in turn combines badly with the high rate of packet loss, and the need to retransmit the whole message if one packet gets lost.  Thus separating sending of the request and sending of the access tokens helps to reduce fragmentation.  <br><br>
+</dd>
+<dt>Client Credentials Grant:</dt>
+<dd style="margin-left: 8">
+<br><br> This framework RECOMMENDS the use of the client credentials grant for machine-to-machine communication use cases, where manual intervention of the resource owner to produce a grant token is not feasible.  The intention is that the resource owner would instead pre-arrange authorization with the AS, based on the client's own credentials.  The client can the (without manual intervention) obtain access tokens from the AS.  <br><br>
+</dd>
+<dt>Introspection:</dt>
+<dd style="margin-left: 8">
+<br><br> This framework RECOMMENDS the use of access token introspection in cases where the client is constrained in a way that it can not easily obtain new access tokens (i.e. it has connectivity issues that prevent it from communicating with the AS). In that case this framework RECOMMENDS the use of a long-term token, that could be a simple reference.  The RS is assumed to be able to communicate with the AS, and can therefore perform introspection, in order to learn the claims associated with the token reference.  The advantage of such an approach is that the resource owner can change the claims associated to the token reference without having to be in contact with the client, thus granting or revoking access rights.  <br><br>
+</dd>
+<dt>Client Token:</dt>
+<dd style="margin-left: 8">
+<br><br> In cases where the client is constrained and does not have connectivity to the AS, and furthermore does not have a previous security relation to the RS that it needs to communicate with, this framework proposes the use of "client tokens".  A client token is a data object obtained from the AS by the RS, during access token introspection.  The RS passes the client token on to the client.  It contains information that allows the client to perform the proof of possession for its access token and to authenticate the RS (e.g. with it's public key).  </dd>
 </dl>
 
 <p> </p>
-<h1 id="rfc.appendix.B"><a href="#rfc.appendix.B">Appendix B.</a> <a href="#app:rolesAndResponsibilities" id="app:rolesAndResponsibilities">Roles and Responsibilities</a></h1>
-<p/>
+<h1 id="rfc.appendix.B">
+<a href="#rfc.appendix.B">Appendix B.</a> <a href="#app:rolesAndResponsibilities" id="app:rolesAndResponsibilities">Roles and Responsibilities</a>
+</h1>
+<p></p>
 
 <dl>
-  <dt>Resource Owner</dt>
-  <dd style="margin-left: 8"><ul><li>Make sure that the RS is registered at the AS.  This includes making known to the AS which profiles, token_types, scopes, and key types (symmetric/asymmetric) the RS supports. Also making it known to the AS which audience(s) the RS identifies itself with.</li><li>Make sure that clients can discover the AS that is in charge of the RS.</li><li>If the client-credentials grant is used, make sure that the AS has the necessary, up-to-date, access control policies for the RS.</li></ul><p> </p><br/> </dd>
-  <dt>Requesting Party</dt>
-  <dd style="margin-left: 8"><ul><li>Make sure that the client is provisioned the necessary credentials to authenticate to the AS.</li><li>Make sure that the client is configured to follow the security requirements of the Requesting Party when issuing requests (e.g., minimum communication security requirements, trust anchors).</li><li>Register the client at the AS.  This includes making known to the AS which profiles, token_types, and key types (symmetric/asymmetric) the client.</li></ul><p> </p><br/> </dd>
-  <dt>Authorization Server</dt>
-  <dd style="margin-left: 8"><ul><li>Register the RS and manage corresponding security contexts.</li><li>Register clients and authentication credentials.</li><li>Allow Resource Owners to configure and update access control policies related to their registered RSs.</li><li>Expose the token endpoint to allow  clients to request tokens.</li><li>Authenticate clients that wish to request a token.</li><li>Process a token request using the authorization policies configured for the RS.</li><li>Optionally:  Expose the introspection endpoint that allows RS's to submit token introspection requests.</li><li>If providing an introspection endpoint: Authenticate RSs that wish to get an introspection response.</li><li>If providing an introspection endpoint: Process token introspection requests.</li><li>Optionally: Handle token revocation.</li><li>Optionally: Provide discovery metadata. See <a href="#I-D.ietf-oauth-discovery">[I-D.ietf-oauth-discovery]</a></li></ul><br/> </dd>
-  <dt>Client</dt>
-  <dd style="margin-left: 8"><ul><li>Discover the AS in charge of the RS that is to be targeted with a request.</li><li>Submit the token request (see step (A) of <a href="#fig:protocolFlow">Figure 1</a>).  <ul><li>Authenticate to the AS.</li><li>Optionally (if not pre-configured): Specify which RS, which resource(s), and which action(s) the request(s) will target.</li><li>If raw public keys (rpk) or certificates are used, make sure the AS has the right rpk or certificate for this client.</li></ul><p> </p></li><li>Process the access token and RS Information (see step (B) of <a href="#fig:protocolFlow">Figure 1</a>).  <ul><li>Check that the RS Information provides the necessary security parameters (e.g., PoP key, information on communication security protocols supported by the RS).</li></ul><p> </p></li><li>Send the token and request to the RS (see step (C) of <a href="#fig:protocolFlow">Figure 1</a>).  <ul><li>Authenticate towards the RS (this could coincide with the proof of possession process).</li><li>Transmit the token as specified by the AS (default is to the authz-info endpoint, alternative options are specified by profiles).</li><li>Perform the proof-of-possession procedure as specified by the profile in use (this may already have been taken care of through the authentication procedure).</li></ul><p> </p></li><li>Process the RS response (see step (F) of <a href="#fig:protocolFlow">Figure 1</a>) of the RS.</li></ul><br/> </dd>
-  <dt>Resource Server</dt>
-  <dd style="margin-left: 8">
-    <ul>
-      <li>Expose a way to submit access tokens. By default this is the authz-info endpoint.</li>
-      <li>Process an access token.  <ul><li>Verify the token is from a recognized AS.</li><li>Verify that the token applies to this RS.</li><li>Check that the token has not expired (if the token provides expiration information).</li><li>Check the token's integrity.</li><li>Store the token so that it can be retrieved in the context of a matching request.</li></ul><p> </p></li>
-      <li>Process a request.  <ul><li>Set up communication security with the client.</li><li>Authenticate the client.</li><li>Match the client against existing tokens.</li><li>Check that tokens belonging to the client actually authorize the requested action.</li><li>Optionally: Check that the matching tokens are still valid, using introspection (if this is possible.)</li></ul><p> </p></li>
-      <li>Send a response following the agreed upon communication security.</li>
-    </ul>
-    <p> </p>
-  </dd>
+<dt>Resource Owner</dt>
+<dd style="margin-left: 8">
+<ul>
+<li>Make sure that the RS is registered at the AS.  This includes making known to the AS which profiles, token_types, scopes, and key types (symmetric/asymmetric) the RS supports. Also making it known to the AS which audience(s) the RS identifies itself with.</li>
+<li>Make sure that clients can discover the AS that is in charge of the RS.</li>
+<li>If the client-credentials grant is used, make sure that the AS has the necessary, up-to-date, access control policies for the RS.</li>
+</ul>
+<p> </p>
+<br> </dd>
+<dt>Requesting Party</dt>
+<dd style="margin-left: 8">
+<ul>
+<li>Make sure that the client is provisioned the necessary credentials to authenticate to the AS.</li>
+<li>Make sure that the client is configured to follow the security requirements of the Requesting Party when issuing requests (e.g., minimum communication security requirements, trust anchors).</li>
+<li>Register the client at the AS.  This includes making known to the AS which profiles, token_types, and key types (symmetric/asymmetric) the client.</li>
+</ul>
+<p> </p>
+<br> </dd>
+<dt>Authorization Server</dt>
+<dd style="margin-left: 8">
+<ul>
+<li>Register the RS and manage corresponding security contexts.</li>
+<li>Register clients and authentication credentials.</li>
+<li>Allow Resource Owners to configure and update access control policies related to their registered RSs.</li>
+<li>Expose the token endpoint to allow  clients to request tokens.</li>
+<li>Authenticate clients that wish to request a token.</li>
+<li>Process a token request using the authorization policies configured for the RS.</li>
+<li>Optionally:  Expose the introspection endpoint that allows RS's to submit token introspection requests.</li>
+<li>If providing an introspection endpoint: Authenticate RSs that wish to get an introspection response.</li>
+<li>If providing an introspection endpoint: Process token introspection requests.</li>
+<li>Optionally: Handle token revocation.</li>
+<li>Optionally: Provide discovery metadata. See <a href="#I-D.ietf-oauth-discovery" class="xref">[I-D.ietf-oauth-discovery]</a>
+</li>
+</ul>
+<br> </dd>
+<dt>Client</dt>
+<dd style="margin-left: 8">
+<ul>
+<li>Discover the AS in charge of the RS that is to be targeted with a request.</li>
+<li>Submit the token request (see step (A) of <a href="#fig:protocolFlow" class="xref">Figure 1</a>).  <ul>
+<li>Authenticate to the AS.</li>
+<li>Optionally (if not pre-configured): Specify which RS, which resource(s), and which action(s) the request(s) will target.</li>
+<li>If raw public keys (rpk) or certificates are used, make sure the AS has the right rpk or certificate for this client.</li>
+</ul>
+<p> </p>
+</li>
+<li>Process the access token and RS Information (see step (B) of <a href="#fig:protocolFlow" class="xref">Figure 1</a>).  <ul><li>Check that the RS Information provides the necessary security parameters (e.g., PoP key, information on communication security protocols supported by the RS).</li></ul>
+<p> </p>
+</li>
+<li>Send the token and request to the RS (see step (C) of <a href="#fig:protocolFlow" class="xref">Figure 1</a>).  <ul>
+<li>Authenticate towards the RS (this could coincide with the proof of possession process).</li>
+<li>Transmit the token as specified by the AS (default is to the authz-info endpoint, alternative options are specified by profiles).</li>
+<li>Perform the proof-of-possession procedure as specified by the profile in use (this may already have been taken care of through the authentication procedure).</li>
+</ul>
+<p> </p>
+</li>
+<li>Process the RS response (see step (F) of <a href="#fig:protocolFlow" class="xref">Figure 1</a>) of the RS.</li>
+</ul>
+<br> </dd>
+<dt>Resource Server</dt>
+<dd style="margin-left: 8">
+<ul>
+<li>Expose a way to submit access tokens. By default this is the authz-info endpoint.</li>
+<li>Process an access token.  <ul>
+<li>Verify the token is from a recognized AS.</li>
+<li>Verify that the token applies to this RS.</li>
+<li>Check that the token has not expired (if the token provides expiration information).</li>
+<li>Check the token's integrity.</li>
+<li>Store the token so that it can be retrieved in the context of a matching request.</li>
+</ul>
+<p> </p>
+</li>
+<li>Process a request.  <ul>
+<li>Set up communication security with the client.</li>
+<li>Authenticate the client.</li>
+<li>Match the client against existing tokens.</li>
+<li>Check that tokens belonging to the client actually authorize the requested action.</li>
+<li>Optionally: Check that the matching tokens are still valid, using introspection (if this is possible.)</li>
+</ul>
+<p> </p>
+</li>
+<li>Send a response following the agreed upon communication security.</li>
+</ul>
+<p> </p>
+</dd>
 </dl>
-<h1 id="rfc.appendix.C"><a href="#rfc.appendix.C">Appendix C.</a> <a href="#app:profileRequirements" id="app:profileRequirements">Requirements on Profiles</a></h1>
+<h1 id="rfc.appendix.C">
+<a href="#rfc.appendix.C">Appendix C.</a> <a href="#app:profileRequirements" id="app:profileRequirements">Requirements on Profiles</a>
+</h1>
 <p id="rfc.section.C.p.1">This section lists the requirements on profiles of this framework, for the convenience of profile designers.  </p>
 
 <ul>
-  <li>Specify the communication protocol the client and RS the must use (e.g., CoAP). <a href="#oauthProfile">Section 5</a> and <a href="#paramProfile">Section 5.6.4.4</a></li>
-  <li>Specify the security protocol the client and RS must use to protect their communication (e.g., OSCOAP or DTLS over CoAP).  This must provide encryption, integrity and replay protection. <a href="#paramProfile">Section 5.6.4.4</a></li>
-  <li>Specify how the client and the RS mutually authenticate. <a href="#specs">Section 4</a></li>
-  <li>Specify the Content-format of the protocol messages (e.g., "application/cbor" or "application/cose+cbor"). <a href="#specs">Section 4</a></li>
-  <li>Specify the proof-of-possession protocol(s) and how to select one, if several are available.  Also specify which key types (e.g., symmetric/asymmetric) are supported by a specific proof-of-possession protocol. <a href="#paramTokenType">Section 5.6.4.3</a></li>
-  <li>Specify a unique profile identifier. <a href="#paramProfile">Section 5.6.4.4</a></li>
-  <li>If introspection is supported: Specify the communication and security protocol for introspection.<a href="#introspectionEndpoint">Section 5.7</a></li>
-  <li>Specify the communication and security protocol for interactions between client and AS. <a href="#tokenEndpoint">Section 5.6</a></li>
-  <li>Specify how/if the authz-info endpoint is protected. <a href="#tokenAuthInfoEndpoint">Section 5.8.1</a></li>
-  <li>Optionally define other methods of token transport than the authz-info endpoint. <a href="#tokenAuthInfoEndpoint">Section 5.8.1</a></li>
+<li>Specify the communication protocol the client and RS the must use (e.g., CoAP). <a href="#oauthProfile" class="xref">Section 5</a> and <a href="#paramProfile" class="xref">Section 5.6.4.4</a>
+</li>
+<li>Specify the security protocol the client and RS must use to protect their communication (e.g., OSCOAP or DTLS over CoAP).  This must provide encryption, integrity and replay protection. <a href="#paramProfile" class="xref">Section 5.6.4.4</a>
+</li>
+<li>Specify how the client and the RS mutually authenticate. <a href="#specs" class="xref">Section 4</a>
+</li>
+<li>Specify the Content-format of the protocol messages (e.g., "application/cbor" or "application/cose+cbor"). <a href="#specs" class="xref">Section 4</a>
+</li>
+<li>Specify the proof-of-possession protocol(s) and how to select one, if several are available.  Also specify which key types (e.g., symmetric/asymmetric) are supported by a specific proof-of-possession protocol. <a href="#paramTokenType" class="xref">Section 5.6.4.3</a>
+</li>
+<li>Specify a unique profile identifier. <a href="#paramProfile" class="xref">Section 5.6.4.4</a>
+</li>
+<li>If introspection is supported: Specify the communication and security protocol for introspection.<a href="#introspectionEndpoint" class="xref">Section 5.7</a>
+</li>
+<li>Specify the communication and security protocol for interactions between client and AS. <a href="#tokenEndpoint" class="xref">Section 5.6</a>
+</li>
+<li>Specify how/if the authz-info endpoint is protected. <a href="#tokenAuthInfoEndpoint" class="xref">Section 5.8.1</a>
+</li>
+<li>Optionally define other methods of token transport than the authz-info endpoint. <a href="#tokenAuthInfoEndpoint" class="xref">Section 5.8.1</a>
+</li>
 </ul>
 
 <p> </p>
-<h1 id="rfc.appendix.D"><a href="#rfc.appendix.D">Appendix D.</a> <a href="#app:registration" id="app:registration">Assumptions on AS knowledge about C and RS</a></h1>
+<h1 id="rfc.appendix.D">
+<a href="#rfc.appendix.D">Appendix D.</a> <a href="#app:registration" id="app:registration">Assumptions on AS knowledge about C and RS</a>
+</h1>
 <p id="rfc.section.D.p.1">This section lists the assumptions on what an AS should know about a client and a RS in order to be able to respond to requests to the token and introspection endpoints.  How this information is established is out of scope for this document.  </p>
 
 <ul>
-  <li>The identifier of the client or RS.</li>
-  <li>The profiles that the client or RS supports.</li>
-  <li>The scopes that the RS supports.</li>
-  <li>The audiences that the RS identifies with.</li>
-  <li>The key types (e.g., pre-shared symmetric key, raw public key, key length, other key parameters) that the client or RS supports.</li>
-  <li>The types of access tokens the RS supports (e.g., CWT).</li>
-  <li>If the RS supports CWTs, the COSE parameters for the crypto wrapper (e.g., algorithm, key-wrap algorithm, key-length).</li>
-  <li>The expiration time for access tokens issued to this RS (unless the RS accepts a default time chosen by the AS).</li>
-  <li>The symmetric key shared between client or RS and AS (if any).</li>
-  <li>The raw public key of the client or RS (if any).</li>
+<li>The identifier of the client or RS.</li>
+<li>The profiles that the client or RS supports.</li>
+<li>The scopes that the RS supports.</li>
+<li>The audiences that the RS identifies with.</li>
+<li>The key types (e.g., pre-shared symmetric key, raw public key, key length, other key parameters) that the client or RS supports.</li>
+<li>The types of access tokens the RS supports (e.g., CWT).</li>
+<li>If the RS supports CWTs, the COSE parameters for the crypto wrapper (e.g., algorithm, key-wrap algorithm, key-length).</li>
+<li>The expiration time for access tokens issued to this RS (unless the RS accepts a default time chosen by the AS).</li>
+<li>The symmetric key shared between client or RS and AS (if any).</li>
+<li>The raw public key of the client or RS (if any).</li>
 </ul>
 
 <p> </p>
-<h1 id="rfc.appendix.E"><a href="#rfc.appendix.E">Appendix E.</a> <a href="#options" id="options">Deployment Examples</a></h1>
-<p id="rfc.section.E.p.1">There is a large variety of IoT deployments, as is indicated in <a href="#constraints">Appendix A</a>, and this section highlights a few common variants.  This section is not normative but illustrates how the framework can be applied.  </p>
+<h1 id="rfc.appendix.E">
+<a href="#rfc.appendix.E">Appendix E.</a> <a href="#options" id="options">Deployment Examples</a>
+</h1>
+<p id="rfc.section.E.p.1">There is a large variety of IoT deployments, as is indicated in <a href="#constraints" class="xref">Appendix A</a>, and this section highlights a few common variants.  This section is not normative but illustrates how the framework can be applied.  </p>
 <p id="rfc.section.E.p.2">For each of the deployment variants, there are a number of possible security setups between clients, resource servers and authorization servers.  The main focus in the following subsections is on how authorization of a client request for a resource hosted by a RS is performed.  This requires the security of the requests and responses between the clients and the RS to consider.  </p>
 <p id="rfc.section.E.p.3">Note: CBOR diagnostic notation is used for examples of requests and responses.</p>
-<h1 id="rfc.appendix.E.1"><a href="#rfc.appendix.E.1">E.1.</a> <a href="#localTokenValidation" id="localTokenValidation">Local Token Validation</a></h1>
-<p id="rfc.section.E.1.p.1">In this scenario, the case where the resource server is offline is considered, i.e., it is not connected to the AS at the time of the access request.  This access procedure involves steps A, B, C, and F of <a href="#fig:protocolFlow">Figure 1</a>.  </p>
+<h1 id="rfc.appendix.E.1">
+<a href="#rfc.appendix.E.1">E.1.</a> <a href="#localTokenValidation" id="localTokenValidation">Local Token Validation</a>
+</h1>
+<p id="rfc.section.E.1.p.1">In this scenario, the case where the resource server is offline is considered, i.e., it is not connected to the AS at the time of the access request.  This access procedure involves steps A, B, C, and F of <a href="#fig:protocolFlow" class="xref">Figure 1</a>.  </p>
 <p id="rfc.section.E.1.p.2">Since the resource server must be able to verify the access token locally, self-contained access tokens must be used.</p>
-<p id="rfc.section.E.1.p.3">This example shows the interactions between a client, the authorization server and a temperature sensor acting as a resource server.  Message exchanges A and B are shown in <a href="#fig:RSOffline">Figure 17</a>.</p>
-<p/>
+<p id="rfc.section.E.1.p.3">This example shows the interactions between a client, the authorization server and a temperature sensor acting as a resource server.  Message exchanges A and B are shown in <a href="#fig:RSOffline" class="xref">Figure 17</a>.</p>
+<p></p>
 
 <dl>
-  <dt></dt>
-  <dd style="margin-left: 8">A: The client first generates a public-private key pair used for communication security with the RS.</dd>
-  <dt></dt>
-  <dd style="margin-left: 8">The client sends the POST request to the token endpoint at the AS.  The security of this request can be transport or application layer. It is up the the communication security profile to define. In the example transport layer identification of the AS is done and the client identifies with client_id and client_secret as in classic OAuth.  The request contains the public key of the client and the Audience parameter set to "tempSensorInLivingRoom", a value that the temperature sensor identifies itself with.  The AS evaluates the request and authorizes the client to access the resource.</dd>
-  <dt></dt>
-  <dd style="margin-left: 8">B: The AS responds with a PoP access token and RS Information.  The PoP access token contains the public key of the client, and the RS Information contains the public key of the RS.  For communication security this example uses DTLS RawPublicKey between the client and the RS. The issued token will have a short validity time, i.e., "exp" close to "iat", to protect the RS from replay attacks. The token includes the claim such as "scope" with the authorized access that an owner of the temperature device can enjoy.  In this example, the "scope" claim, issued by the AS, informs the RS that the owner of the token, that can prove the possession of a key is authorized to make a GET request against the /temperature resource and a POST request on the /firmware resource.  Note that the syntax and semantics of the scope claim are application specific.</dd>
-  <dt></dt>
-  <dd style="margin-left: 8">Note: In this example it is assumed that the client knows what resource it wants to access, and is therefore able to request specific audience and scope claims for the access token.</dd>
+<dt></dt>
+<dd style="margin-left: 8">A: The client first generates a public-private key pair used for communication security with the RS.</dd>
+<dt></dt>
+<dd style="margin-left: 8">The client sends the POST request to the token endpoint at the AS.  The security of this request can be transport or application layer. It is up the the communication security profile to define. In the example transport layer identification of the AS is done and the client identifies with client_id and client_secret as in classic OAuth.  The request contains the public key of the client and the Audience parameter set to "tempSensorInLivingRoom", a value that the temperature sensor identifies itself with.  The AS evaluates the request and authorizes the client to access the resource.</dd>
+<dt></dt>
+<dd style="margin-left: 8">B: The AS responds with a PoP access token and RS Information.  The PoP access token contains the public key of the client, and the RS Information contains the public key of the RS.  For communication security this example uses DTLS RawPublicKey between the client and the RS. The issued token will have a short validity time, i.e., "exp" close to "iat", to protect the RS from replay attacks. The token includes the claim such as "scope" with the authorized access that an owner of the temperature device can enjoy.  In this example, the "scope" claim, issued by the AS, informs the RS that the owner of the token, that can prove the possession of a key is authorized to make a GET request against the /temperature resource and a POST request on the /firmware resource.  Note that the syntax and semantics of the scope claim are application specific.</dd>
+<dt></dt>
+<dd style="margin-left: 8">Note: In this example it is assumed that the client knows what resource it wants to access, and is therefore able to request specific audience and scope claims for the access token.</dd>
 </dl>
-<div id="rfc.figure.17"/>
-<div id="fig:RSOffline"/>
+<div id="rfc.figure.17"></div>
+<div id="fig:RSOffline"></div>
 <pre>
          Authorization
   Client    Server
@@ -1835,9 +2143,9 @@ B:  |&lt;--------+ Header: 2.05 Content
     |         |
         </pre>
 <p class="figure">Figure 17: Token Request and Response Using Client Credentials.</p>
-<p/>
-<div id="rfc.figure.18"/>
-<div id="fig:RSOfflineReq"/>
+<p></p>
+<div id="rfc.figure.18"></div>
+<div id="fig:RSOfflineReq"></div>
 <pre>
 Request-Payload :
 {
@@ -1864,10 +2172,10 @@ Response-Payload :
 }
         </pre>
 <p class="figure">Figure 18: Request and Response Payload Details.</p>
-<p id="rfc.section.E.1.p.6">The information contained in the Request-Payload and the Response-Payload is shown in <a href="#fig:RSOfflineReq">Figure 18</a>.  Note that a transport layer security based communication security profile is used in this example, therefore the Content-Type is "application/cbor".  </p>
-<p id="rfc.section.E.1.p.7">The content of the access token is shown in  <a href="#fig:BothcborMappingValueAsymmetricCWT">Figure 19</a>.</p>
-<div id="rfc.figure.19"/>
-<div id="fig:BothcborMappingValueAsymmetricCWT"/>
+<p id="rfc.section.E.1.p.6">The information contained in the Request-Payload and the Response-Payload is shown in <a href="#fig:RSOfflineReq" class="xref">Figure 18</a>.  Note that a transport layer security based communication security profile is used in this example, therefore the Content-Type is "application/cbor".  </p>
+<p id="rfc.section.E.1.p.7">The content of the access token is shown in  <a href="#fig:BothcborMappingValueAsymmetricCWT" class="xref">Figure 19</a>.</p>
+<div id="rfc.figure.19"></div>
+<div id="fig:BothcborMappingValueAsymmetricCWT"></div>
 <pre>
 {
   "aud" : "tempSensorInLivingRoom",
@@ -1886,9 +2194,9 @@ Response-Payload :
 }
         </pre>
 <p class="figure">Figure 19: Access Token including Public Key of the Client.</p>
-<p/>
-<div id="rfc.figure.20"/>
-<div id="fig:RSOfflinePostAccessTokenAsymmetric"/>
+<p></p>
+<div id="rfc.figure.20"></div>
+<div id="fig:RSOfflinePostAccessTokenAsymmetric"></div>
 <pre>
            Resource
  Client     Server
@@ -1902,22 +2210,22 @@ C:  +--------&gt;| Header: POST (Code=0.02)
     |         |
 </pre>
 <p class="figure">Figure 20: Access Token provisioning to RS</p>
-<p id="rfc.section.E.1.p.9">Messages C and F are shown in <a href="#fig:RSOfflinePostAccessTokenAsymmetric">Figure 20</a> - <a href="#fig:RSOfflineDTLSRequestAndResponse">Figure 21</a>.  </p>
+<p id="rfc.section.E.1.p.9">Messages C and F are shown in <a href="#fig:RSOfflinePostAccessTokenAsymmetric" class="xref">Figure 20</a> - <a href="#fig:RSOfflineDTLSRequestAndResponse" class="xref">Figure 21</a>.  </p>
 
 <dl>
-  <dt></dt>
-  <dd style="margin-left: 8">C: The client then sends the PoP access token to the authz-info endpoint at the RS.  This is a plain CoAP request, i.e., no transport or application layer security between client and RS, since the token is integrity protected between the AS and RS.  The RS verifies that the PoP access token was created by a known and trusted AS, is valid, and responds to the client.  The RS caches the security context together with authorization information about this client contained in the PoP access token.</dd>
-  <dt></dt>
-  <dd style="margin-left: 8"/>
-  <dt></dt>
-  <dd style="margin-left: 8">The client and the RS runs the DTLS handshake using the raw public keys established in step B and C.</dd>
-  <dt></dt>
-  <dd style="margin-left: 8">The client sends the CoAP request GET to /temperature on RS over DTLS.  The RS verifies that the request is authorized, based on previously established security context.</dd>
-  <dt></dt>
-  <dd style="margin-left: 8">F: The RS responds with a resource representation over DTLS.</dd>
+<dt></dt>
+<dd style="margin-left: 8">C: The client then sends the PoP access token to the authz-info endpoint at the RS.  This is a plain CoAP request, i.e., no transport or application layer security between client and RS, since the token is integrity protected between the AS and RS.  The RS verifies that the PoP access token was created by a known and trusted AS, is valid, and responds to the client.  The RS caches the security context together with authorization information about this client contained in the PoP access token.</dd>
+<dt></dt>
+<dd style="margin-left: 8"></dd>
+<dt></dt>
+<dd style="margin-left: 8">The client and the RS runs the DTLS handshake using the raw public keys established in step B and C.</dd>
+<dt></dt>
+<dd style="margin-left: 8">The client sends the CoAP request GET to /temperature on RS over DTLS.  The RS verifies that the request is authorized, based on previously established security context.</dd>
+<dt></dt>
+<dd style="margin-left: 8">F: The RS responds with a resource representation over DTLS.</dd>
 </dl>
-<div id="rfc.figure.21"/>
-<div id="fig:RSOfflineDTLSRequestAndResponse"/>
+<div id="rfc.figure.21"></div>
+<div id="fig:RSOfflineDTLSRequestAndResponse"></div>
 <pre>
            Resource
  Client     Server
@@ -1935,25 +2243,27 @@ F:  |&lt;--------+ Header: 2.05 Content
     |         |
       </pre>
 <p class="figure">Figure 21: Resource Request and Response protected by DTLS.</p>
-<p/>
-<h1 id="rfc.appendix.E.2"><a href="#rfc.appendix.E.2">E.2.</a> <a href="#introspectionAidedTokenValidation" id="introspectionAidedTokenValidation">Introspection Aided Token Validation</a></h1>
-<p id="rfc.section.E.2.p.1">In this deployment scenario it is assumed that a client is not able to access the AS at the time of the access request, whereas the RS is assumed to be connected to the back-end infrastructure. Thus the RS can make use of token introspection.  This access procedure involves steps A-F of <a href="#fig:protocolFlow">Figure 1</a>, but assumes steps A and B have been carried out during a phase when the client had connectivity to AS.  </p>
+<p></p>
+<h1 id="rfc.appendix.E.2">
+<a href="#rfc.appendix.E.2">E.2.</a> <a href="#introspectionAidedTokenValidation" id="introspectionAidedTokenValidation">Introspection Aided Token Validation</a>
+</h1>
+<p id="rfc.section.E.2.p.1">In this deployment scenario it is assumed that a client is not able to access the AS at the time of the access request, whereas the RS is assumed to be connected to the back-end infrastructure. Thus the RS can make use of token introspection.  This access procedure involves steps A-F of <a href="#fig:protocolFlow" class="xref">Figure 1</a>, but assumes steps A and B have been carried out during a phase when the client had connectivity to AS.  </p>
 <p id="rfc.section.E.2.p.2">Since the client is assumed to be offline, at least for a certain period of time, a pre-provisioned access token has to be long-lived.  Since the client is constrained, the token will not be self contained (i.e. not a CWT) but instead just a reference.  The resource server uses its connectivity to learn about the claims associated to the access token by using introspection, which is shown in the example below.</p>
-<p id="rfc.section.E.2.p.3">In the example interactions between an offline client (key fob), a RS (online lock), and an AS is shown.  It is assumed that there is a provisioning step where the client has access to the AS.  This corresponds to message exchanges A and B which are shown in <a href="#fig:cOffline">Figure 22</a>.  </p>
+<p id="rfc.section.E.2.p.3">In the example interactions between an offline client (key fob), a RS (online lock), and an AS is shown.  It is assumed that there is a provisioning step where the client has access to the AS.  This corresponds to message exchanges A and B which are shown in <a href="#fig:cOffline" class="xref">Figure 22</a>.  </p>
 <p id="rfc.section.E.2.p.4">Authorization consent from the resource owner can be pre-configured, but it can also be provided via an interactive flow with the resource owner.  An example of this for the key fob case could be that the resource owner has a connected car, he buys a generic key that he wants to use with the car.  To authorize the key fob he connects it to his computer that then provides the UI for the device.  After that OAuth 2.0 implicit flow can used to authorize the key for his car at the the car manufacturers AS.</p>
 <p id="rfc.section.E.2.p.5">Note: In this example the client does not know the exact door it will be used to access since the token request is not send at the time of access. So the scope and audience parameters are set quite wide to start with and new values different form the original once can be returned from introspection later on.</p>
-<p/>
+<p></p>
 
 <dl>
-  <dt></dt>
-  <dd style="margin-left: 8">A: The client sends the request using POST to the token endpoint at AS.  The request contains the Audience parameter set to  "PACS1337" (PACS, Physical Access System), a value the that the online door in question identifies itself with.  The AS generates an access token as an opaque string, which it can match to the specific client, a targeted audience and a symmetric key. The security is provided by identifying the AS on transport layer using a pre shared security context (psk, rpk or certificate) and then the client is identified using client_id and client_secret as in classic OAuth.</dd>
-  <dt></dt>
-  <dd style="margin-left: 8">B: The AS responds with the an access token and RS Information, the latter containing a symmetric key.  Communication security between C and RS will be DTLS and PreSharedKey.  The PoP key is used as the PreSharedKey.  </dd>
+<dt></dt>
+<dd style="margin-left: 8">A: The client sends the request using POST to the token endpoint at AS.  The request contains the Audience parameter set to  "PACS1337" (PACS, Physical Access System), a value the that the online door in question identifies itself with.  The AS generates an access token as an opaque string, which it can match to the specific client, a targeted audience and a symmetric key. The security is provided by identifying the AS on transport layer using a pre shared security context (psk, rpk or certificate) and then the client is identified using client_id and client_secret as in classic OAuth.</dd>
+<dt></dt>
+<dd style="margin-left: 8">B: The AS responds with the an access token and RS Information, the latter containing a symmetric key.  Communication security between C and RS will be DTLS and PreSharedKey.  The PoP key is used as the PreSharedKey.  </dd>
 </dl>
 
 <p> </p>
-<div id="rfc.figure.22"/>
-<div id="fig:cOffline"/>
+<div id="rfc.figure.22"></div>
+<div id="fig:cOffline"></div>
 <pre>
 
          Authorization
@@ -1971,9 +2281,9 @@ B:  |&lt;--------+ Header: 2.05 Content
     |         |
     </pre>
 <p class="figure">Figure 22: Token Request and Response using Client Credentials.</p>
-<p/>
-<div id="rfc.figure.23"/>
-<div id="fig:cOfflineReq"/>
+<p></p>
+<div id="rfc.figure.23"></div>
+<div id="fig:cOfflineReq"></div>
 <pre>
 Request-Payload:
 {
@@ -1999,10 +2309,10 @@ Response-Payload:
 }
       </pre>
 <p class="figure">Figure 23: Request and Response Payload for C offline</p>
-<p id="rfc.section.E.2.p.8">The information contained in the Request-Payload and the Response-Payload is shown in <a href="#fig:cOfflineReq">Figure 23</a>.  </p>
+<p id="rfc.section.E.2.p.8">The information contained in the Request-Payload and the Response-Payload is shown in <a href="#fig:cOfflineReq" class="xref">Figure 23</a>.  </p>
 <p id="rfc.section.E.2.p.9">The access token in this case is just an opaque string referencing the authorization information at the AS.</p>
-<div id="rfc.figure.24"/>
-<div id="fig:cOfflineIntrospection"/>
+<div id="rfc.figure.24"></div>
+<div id="fig:cOfflineIntrospection"></div>
 <pre>
            Resource
   Client    Server
@@ -2030,8 +2340,8 @@ C:  +--------&gt;| Header: POST (T=CON, Code=0.02)
     |         |
 </pre>
 <p class="figure">Figure 24: Token Introspection for C offline</p>
-<div id="rfc.figure.25"/>
-<div id="fig:cOfflineIntroReq"/>
+<div id="rfc.figure.25"></div>
+<div id="fig:cOfflineIntroReq"></div>
 <pre>
 Request-Payload:
 {
@@ -2052,36 +2362,36 @@ Response-Payload:
 }
           </pre>
 <p class="figure">Figure 25: Request and Response Payload for Introspection</p>
-<p/>
+<p></p>
 
 <dl>
-  <dt></dt>
-  <dd style="margin-left: 8">C: Next, the client POSTs the access token to the authz-info endpoint in the RS.  This is a plain CoAP request, i.e., no DTLS between client and RS.  Since the token is an opaque string, the RS cannot verify it on its own, and thus defers to respond the client with a status code until after step E.</dd>
-  <dt></dt>
-  <dd style="margin-left: 8">D: The RS forwards the token to the introspection endpoint on the AS.  Introspection assumes a secure connection between the AS and the RS, e.g., using transport of application layer security. In the example AS is identified using pre shared security context (psk, rpk or certificate) while RS is acting as client and is identified with client_id and client_secret.  </dd>
-  <dt></dt>
-  <dd style="margin-left: 8">E: The AS provides the introspection response containing parameters about the token.  This includes the confirmation key (cnf) parameter that allows the RS to verify the client's proof of possession in step F.</dd>
-  <dt></dt>
-  <dd style="margin-left: 8">After receiving message E, the RS responds to the client's POST in step C with the CoAP response code 2.01 (Created).</dd>
-  <dt></dt>
-  <dd style="margin-left: 8"/>
-  <dt></dt>
-  <dd style="margin-left: 8">The information contained in the Request-Payload and the Response-Payload is shown in <a href="#fig:cOfflineIntroReq">Figure 25</a>.  </dd>
+<dt></dt>
+<dd style="margin-left: 8">C: Next, the client POSTs the access token to the authz-info endpoint in the RS.  This is a plain CoAP request, i.e., no DTLS between client and RS.  Since the token is an opaque string, the RS cannot verify it on its own, and thus defers to respond the client with a status code until after step E.</dd>
+<dt></dt>
+<dd style="margin-left: 8">D: The RS forwards the token to the introspection endpoint on the AS.  Introspection assumes a secure connection between the AS and the RS, e.g., using transport of application layer security. In the example AS is identified using pre shared security context (psk, rpk or certificate) while RS is acting as client and is identified with client_id and client_secret.  </dd>
+<dt></dt>
+<dd style="margin-left: 8">E: The AS provides the introspection response containing parameters about the token.  This includes the confirmation key (cnf) parameter that allows the RS to verify the client's proof of possession in step F.</dd>
+<dt></dt>
+<dd style="margin-left: 8">After receiving message E, the RS responds to the client's POST in step C with the CoAP response code 2.01 (Created).</dd>
+<dt></dt>
+<dd style="margin-left: 8"></dd>
+<dt></dt>
+<dd style="margin-left: 8">The information contained in the Request-Payload and the Response-Payload is shown in <a href="#fig:cOfflineIntroReq" class="xref">Figure 25</a>.  </dd>
 </dl>
 
 <p> </p>
-<p/>
+<p></p>
 
 <dl>
-  <dt></dt>
-  <dd style="margin-left: 8">The client uses the symmetric PoP key to establish a DTLS PreSharedKey secure connection to the RS. The CoAP request PUT is sent to the uri-path /state on the RS, changing the state of the door to locked.  </dd>
-  <dt></dt>
-  <dd style="margin-left: 8">F: The RS responds with a appropriate over the secure DTLS channel.  </dd>
+<dt></dt>
+<dd style="margin-left: 8">The client uses the symmetric PoP key to establish a DTLS PreSharedKey secure connection to the RS. The CoAP request PUT is sent to the uri-path /state on the RS, changing the state of the door to locked.  </dd>
+<dt></dt>
+<dd style="margin-left: 8">F: The RS responds with a appropriate over the secure DTLS channel.  </dd>
 </dl>
 
 <p> </p>
-<div id="rfc.figure.26"/>
-<div id="fig:cOfflineDTLSRequestAndResponse"/>
+<div id="rfc.figure.26"></div>
+<div id="fig:cOfflineDTLSRequestAndResponse"></div>
 <pre>
            Resource
   Client    Server
@@ -2098,122 +2408,152 @@ F:  |&lt;--------+ Header: 2.04 Changed
     |         |
             </pre>
 <p class="figure">Figure 26: Resource request and response protected by OSCOAP</p>
-<p/>
-<h1 id="rfc.appendix.F"><a href="#rfc.appendix.F">Appendix F.</a> <a href="#app:changelog" id="app:changelog">Document Updates</a></h1>
-<h1 id="rfc.appendix.F.1"><a href="#rfc.appendix.F.1">F.1.</a> <a href="#app:f10t11" id="app:f10t11">Version -09 to -10</a></h1>
-<p/>
-
-<ul>
-  <li>Removed CBOR major type numbers.</li>
-</ul>
-<h1 id="rfc.appendix.F.2"><a href="#rfc.appendix.F.2">F.2.</a> <a href="#app:f9t10" id="app:f9t10">Version -08 to -09</a></h1>
-<p/>
-
-<ul>
-  <li>Allowed scope to be byte arrays.</li>
-  <li>Defined default names for endpoints.</li>
-  <li>Refactored the IANA section for briefness and consistency.</li>
-  <li>Refactored tables that define IANA registry contents for consistency.</li>
-  <li>Created IANA registry for CBOR mappings of error codes, grant types and Authorization Server Information.</li>
-  <li>Added references to other document sections defining IANA entries in the IANA section.</li>
-</ul>
-<h1 id="rfc.appendix.F.3"><a href="#rfc.appendix.F.3">F.3.</a> <a href="#app:f8t9" id="app:f8t9">Version -07 to -08</a></h1>
-<p/>
-
-<ul>
-  <li>Moved AS discovery from the DTLS profile to the framework, see <a href="#asDiscovery">Section 5.1</a>.</li>
-  <li>Made the use of CBOR mandatory. If you use JSON you can use vanilla OAuth.</li>
-  <li>Made it mandatory for profiles to specify C-AS security and RS-AS security (the latter only if introspection is supported).</li>
-  <li>Made the use of CBOR abbreviations mandatory.</li>
-  <li>Added text to clarify the use of token references as an alternative to CWTs.</li>
-  <li>Added text to clarify that introspection must not be delayed, in case the RS has to return a client token.</li>
-  <li>Added security considerations about leakage through unprotected AS discovery information, combining profiles and leakage through error responses.</li>
-  <li>Added privacy considerations about leakage through unprotected AS discovery.</li>
-  <li>Added text that clarifies that introspection is optional.</li>
-  <li>Made profile parameter optional since it can be implicit.</li>
-  <li>Clarified that CoAP is not mandatory and other protocols can be used.</li>
-  <li>Clarified the design justification for specific features of the framework in appendix A.</li>
-  <li>Clarified appendix E.2.</li>
-  <li>Removed specification of the "cnf" claim for CBOR/COSE, and replaced with references to <a href="#I-D.ietf-ace-cwt-proof-of-possession">[I-D.ietf-ace-cwt-proof-of-possession]</a></li>
-</ul>
-<h1 id="rfc.appendix.F.4"><a href="#rfc.appendix.F.4">F.4.</a> <a href="#app:f7t8" id="app:f7t8">Version -06 to -07</a></h1>
-<p/>
-
-<ul>
-  <li>Various clarifications added.</li>
-  <li>Fixed erroneous author email.</li>
-</ul>
-<h1 id="rfc.appendix.F.5"><a href="#rfc.appendix.F.5">F.5.</a> <a href="#app:f6t7" id="app:f6t7">Version -05 to -06</a></h1>
-<p/>
-
-<ul>
-  <li>Moved sections that define the ACE framework into a subsection of the framework <a href="#oauthProfile">Section 5</a>.</li>
-  <li>Split section on client credentials and grant into two separate sections, <a href="#authorizationGrants">Section 5.2</a>, and  <a href="#clientCredentials">Section 5.3</a>.</li>
-  <li>Added <a href="#ASAuthentication">Section 5.4</a> on AS authentication.</li>
-  <li>Added <a href="#authorizeEndpoint">Section 5.5</a> on the Authorization endpoint.</li>
-</ul>
-<h1 id="rfc.appendix.F.6"><a href="#rfc.appendix.F.6">F.6.</a> <a href="#app:f5t6" id="app:f5t6">Version -04 to -05</a></h1>
-<p/>
-
-<ul>
-  <li>Added RFC 2119 language to the specification of the required behavior of profile specifications.</li>
-  <li>Added <a href="#clientCredentials">Section 5.3</a> on the relation to the OAuth2 grant types.</li>
-  <li>Added CBOR abbreviations for error and the error codes defined in OAuth2.</li>
-  <li>Added clarification about token expiration and long-running requests in <a href="#tokenValidity">Section 5.8.2</a></li>
-  <li>Added security considerations about tokens with symmetric pop keys valid for more than one RS.</li>
-  <li>Added privacy considerations section.</li>
-  <li>Added IANA registry mapping the confirmation types from RFC 7800 to equivalent COSE types.</li>
-  <li>Added appendix D, describing assumptions about what the AS knows about the client and the RS.</li>
-</ul>
-<h1 id="rfc.appendix.F.7"><a href="#rfc.appendix.F.7">F.7.</a> <a href="#app:f4t5" id="app:f4t5">Version -03 to -04</a></h1>
-<p/>
-
-<ul>
-  <li>Added a description of the terms "framework" and "profiles" as used in this document.</li>
-  <li>Clarified protection of access tokens in section 3.1.</li>
-  <li>Clarified uses of the "cnf" parameter in section 6.4.5.</li>
-  <li>Clarified intended use of Client Token in section 7.4.</li>
-</ul>
-<h1 id="rfc.appendix.F.8"><a href="#rfc.appendix.F.8">F.8.</a> <a href="#app:f3t4" id="app:f3t4">Version -02 to -03</a></h1>
-<p/>
-
-<ul>
-  <li>Removed references to draft-ietf-oauth-pop-key-distribution since the status of this draft is unclear.</li>
-  <li>Copied and adapted security considerations from draft-ietf-oauth-pop-key-distribution.</li>
-  <li>Renamed "client information" to "RS information" since it is information about the RS.</li>
-  <li>Clarified the requirements on profiles of this framework.</li>
-  <li>Clarified the token endpoint protocol and removed negotiation of "profile" and "alg" (section 6).</li>
-  <li>Renumbered the abbreviations for claims and parameters to get a consistent numbering across different endpoints.</li>
-  <li>Clarified the introspection endpoint.</li>
-  <li>Renamed token, introspection and authz-info to "endpoint" instead of "resource" to mirror the OAuth 2.0 terminology.</li>
-  <li>Updated the examples in the appendices.</li>
-</ul>
-<h1 id="rfc.appendix.F.9"><a href="#rfc.appendix.F.9">F.9.</a> <a href="#app:f2t3" id="app:f2t3">Version -01 to -02</a></h1>
-<p/>
-
-<ul>
-  <li>Restructured to remove communication security parts.  These shall now be defined in profiles.</li>
-  <li>Restructured section 5 to create new sections on the OAuth endpoints token, introspection and authz-info.</li>
-  <li>Pulled in material from draft-ietf-oauth-pop-key-distribution in order to define proof-of-possession key distribution.</li>
-  <li>Introduced the "cnf" parameter as defined in RFC7800 to reference or transport keys used for proof of possession.</li>
-  <li>Introduced the "client-token" to transport client information from the AS to the client via the RS in conjunction with introspection.</li>
-  <li>Expanded the IANA section to define parameters for token request, introspection and CWT claims.</li>
-  <li>Moved deployment scenarios to the appendix as examples.</li>
-</ul>
-<h1 id="rfc.appendix.F.10"><a href="#rfc.appendix.F.10">F.10.</a> <a href="#app:f1t2" id="app:f1t2">Version -00 to -01</a></h1>
-<p/>
-
-<ul>
-  <li>Changed 5.1. from "Communication Security Protocol" to "Client Information".</li>
-  <li>Major rewrite of 5.1 to clarify the information exchanged between C and AS in the PoP access token request profile for IoT.  <ul><li>Allow the client to indicate preferences for the communication security protocol.</li><li>Defined the term "Client Information" for the additional information returned to the client in addition to the access token.</li><li>Require that the messages between AS and client are secured, either with (D)TLS or with COSE_Encrypted wrappers.</li><li>Removed dependency on OSCOAP and added generic text about object security instead.</li><li>Defined the "rpk" parameter in the client information to transmit the raw public key of the RS from AS to client.</li><li>(D)TLS MUST use the PoP key in the handshake (either as PSK or as client RPK with client authentication).</li><li>Defined the use of x5c, x5t and x5tS256 parameters when a client certificate is used for proof of possession.</li><li>Defined "tktn" parameter for signaling for how to transfer the access token.</li></ul></li>
-  <li>Added 5.2. the CoAP Access-Token option for transferring access tokens in messages that do not have payload.</li>
-  <li>5.3.2. Defined success and error responses from the RS when receiving an access token.</li>
-  <li>5.6.:Added section giving guidance on how to handle token expiration in the absence of reliable time.</li>
-  <li>Appendix B Added list of roles and responsibilities for C, AS and RS.</li>
-</ul>
-<h1 id="rfc.authors">
-  <a href="#rfc.authors">Authors' Addresses</a>
+<p></p>
+<h1 id="rfc.appendix.F">
+<a href="#rfc.appendix.F">Appendix F.</a> <a href="#app:changelog" id="app:changelog">Document Updates</a>
 </h1>
+<h1 id="rfc.appendix.F.1">
+<a href="#rfc.appendix.F.1">F.1.</a> <a href="#app:f10t11" id="app:f10t11">Version -09 to -10</a>
+</h1>
+<p></p>
+
+<ul><li>Removed CBOR major type numbers.</li></ul>
+<h1 id="rfc.appendix.F.2">
+<a href="#rfc.appendix.F.2">F.2.</a> <a href="#app:f9t10" id="app:f9t10">Version -08 to -09</a>
+</h1>
+<p></p>
+
+<ul>
+<li>Allowed scope to be byte arrays.</li>
+<li>Defined default names for endpoints.</li>
+<li>Refactored the IANA section for briefness and consistency.</li>
+<li>Refactored tables that define IANA registry contents for consistency.</li>
+<li>Created IANA registry for CBOR mappings of error codes, grant types and Authorization Server Information.</li>
+<li>Added references to other document sections defining IANA entries in the IANA section.</li>
+</ul>
+<h1 id="rfc.appendix.F.3">
+<a href="#rfc.appendix.F.3">F.3.</a> <a href="#app:f8t9" id="app:f8t9">Version -07 to -08</a>
+</h1>
+<p></p>
+
+<ul>
+<li>Moved AS discovery from the DTLS profile to the framework, see <a href="#asDiscovery" class="xref">Section 5.1</a>.</li>
+<li>Made the use of CBOR mandatory. If you use JSON you can use vanilla OAuth.</li>
+<li>Made it mandatory for profiles to specify C-AS security and RS-AS security (the latter only if introspection is supported).</li>
+<li>Made the use of CBOR abbreviations mandatory.</li>
+<li>Added text to clarify the use of token references as an alternative to CWTs.</li>
+<li>Added text to clarify that introspection must not be delayed, in case the RS has to return a client token.</li>
+<li>Added security considerations about leakage through unprotected AS discovery information, combining profiles and leakage through error responses.</li>
+<li>Added privacy considerations about leakage through unprotected AS discovery.</li>
+<li>Added text that clarifies that introspection is optional.</li>
+<li>Made profile parameter optional since it can be implicit.</li>
+<li>Clarified that CoAP is not mandatory and other protocols can be used.</li>
+<li>Clarified the design justification for specific features of the framework in appendix A.</li>
+<li>Clarified appendix E.2.</li>
+<li>Removed specification of the "cnf" claim for CBOR/COSE, and replaced with references to <a href="#I-D.ietf-ace-cwt-proof-of-possession" class="xref">[I-D.ietf-ace-cwt-proof-of-possession]</a>
+</li>
+</ul>
+<h1 id="rfc.appendix.F.4">
+<a href="#rfc.appendix.F.4">F.4.</a> <a href="#app:f7t8" id="app:f7t8">Version -06 to -07</a>
+</h1>
+<p></p>
+
+<ul>
+<li>Various clarifications added.</li>
+<li>Fixed erroneous author email.</li>
+</ul>
+<h1 id="rfc.appendix.F.5">
+<a href="#rfc.appendix.F.5">F.5.</a> <a href="#app:f6t7" id="app:f6t7">Version -05 to -06</a>
+</h1>
+<p></p>
+
+<ul>
+<li>Moved sections that define the ACE framework into a subsection of the framework <a href="#oauthProfile" class="xref">Section 5</a>.</li>
+<li>Split section on client credentials and grant into two separate sections, <a href="#authorizationGrants" class="xref">Section 5.2</a>, and  <a href="#clientCredentials" class="xref">Section 5.3</a>.</li>
+<li>Added <a href="#ASAuthentication" class="xref">Section 5.4</a> on AS authentication.</li>
+<li>Added <a href="#authorizeEndpoint" class="xref">Section 5.5</a> on the Authorization endpoint.</li>
+</ul>
+<h1 id="rfc.appendix.F.6">
+<a href="#rfc.appendix.F.6">F.6.</a> <a href="#app:f5t6" id="app:f5t6">Version -04 to -05</a>
+</h1>
+<p></p>
+
+<ul>
+<li>Added RFC 2119 language to the specification of the required behavior of profile specifications.</li>
+<li>Added <a href="#clientCredentials" class="xref">Section 5.3</a> on the relation to the OAuth2 grant types.</li>
+<li>Added CBOR abbreviations for error and the error codes defined in OAuth2.</li>
+<li>Added clarification about token expiration and long-running requests in <a href="#tokenValidity" class="xref">Section 5.8.2</a>
+</li>
+<li>Added security considerations about tokens with symmetric pop keys valid for more than one RS.</li>
+<li>Added privacy considerations section.</li>
+<li>Added IANA registry mapping the confirmation types from RFC 7800 to equivalent COSE types.</li>
+<li>Added appendix D, describing assumptions about what the AS knows about the client and the RS.</li>
+</ul>
+<h1 id="rfc.appendix.F.7">
+<a href="#rfc.appendix.F.7">F.7.</a> <a href="#app:f4t5" id="app:f4t5">Version -03 to -04</a>
+</h1>
+<p></p>
+
+<ul>
+<li>Added a description of the terms "framework" and "profiles" as used in this document.</li>
+<li>Clarified protection of access tokens in section 3.1.</li>
+<li>Clarified uses of the "cnf" parameter in section 6.4.5.</li>
+<li>Clarified intended use of Client Token in section 7.4.</li>
+</ul>
+<h1 id="rfc.appendix.F.8">
+<a href="#rfc.appendix.F.8">F.8.</a> <a href="#app:f3t4" id="app:f3t4">Version -02 to -03</a>
+</h1>
+<p></p>
+
+<ul>
+<li>Removed references to draft-ietf-oauth-pop-key-distribution since the status of this draft is unclear.</li>
+<li>Copied and adapted security considerations from draft-ietf-oauth-pop-key-distribution.</li>
+<li>Renamed "client information" to "RS information" since it is information about the RS.</li>
+<li>Clarified the requirements on profiles of this framework.</li>
+<li>Clarified the token endpoint protocol and removed negotiation of "profile" and "alg" (section 6).</li>
+<li>Renumbered the abbreviations for claims and parameters to get a consistent numbering across different endpoints.</li>
+<li>Clarified the introspection endpoint.</li>
+<li>Renamed token, introspection and authz-info to "endpoint" instead of "resource" to mirror the OAuth 2.0 terminology.</li>
+<li>Updated the examples in the appendices.</li>
+</ul>
+<h1 id="rfc.appendix.F.9">
+<a href="#rfc.appendix.F.9">F.9.</a> <a href="#app:f2t3" id="app:f2t3">Version -01 to -02</a>
+</h1>
+<p></p>
+
+<ul>
+<li>Restructured to remove communication security parts.  These shall now be defined in profiles.</li>
+<li>Restructured section 5 to create new sections on the OAuth endpoints token, introspection and authz-info.</li>
+<li>Pulled in material from draft-ietf-oauth-pop-key-distribution in order to define proof-of-possession key distribution.</li>
+<li>Introduced the "cnf" parameter as defined in RFC7800 to reference or transport keys used for proof of possession.</li>
+<li>Introduced the "client-token" to transport client information from the AS to the client via the RS in conjunction with introspection.</li>
+<li>Expanded the IANA section to define parameters for token request, introspection and CWT claims.</li>
+<li>Moved deployment scenarios to the appendix as examples.</li>
+</ul>
+<h1 id="rfc.appendix.F.10">
+<a href="#rfc.appendix.F.10">F.10.</a> <a href="#app:f1t2" id="app:f1t2">Version -00 to -01</a>
+</h1>
+<p></p>
+
+<ul>
+<li>Changed 5.1. from "Communication Security Protocol" to "Client Information".</li>
+<li>Major rewrite of 5.1 to clarify the information exchanged between C and AS in the PoP access token request profile for IoT.  <ul>
+<li>Allow the client to indicate preferences for the communication security protocol.</li>
+<li>Defined the term "Client Information" for the additional information returned to the client in addition to the access token.</li>
+<li>Require that the messages between AS and client are secured, either with (D)TLS or with COSE_Encrypted wrappers.</li>
+<li>Removed dependency on OSCOAP and added generic text about object security instead.</li>
+<li>Defined the "rpk" parameter in the client information to transmit the raw public key of the RS from AS to client.</li>
+<li>(D)TLS MUST use the PoP key in the handshake (either as PSK or as client RPK with client authentication).</li>
+<li>Defined the use of x5c, x5t and x5tS256 parameters when a client certificate is used for proof of possession.</li>
+<li>Defined "tktn" parameter for signaling for how to transfer the access token.</li>
+</ul>
+</li>
+<li>Added 5.2. the CoAP Access-Token option for transferring access tokens in messages that do not have payload.</li>
+<li>5.3.2. Defined success and error responses from the RS when receiving an access token.</li>
+<li>5.6.:Added section giving guidance on how to handle token expiration in the absence of reliable time.</li>
+<li>Appendix B Added list of roles and responsibilities for C, AS and RS.</li>
+</ul>
+<h1 id="rfc.authors"><a href="#rfc.authors">Authors' Addresses</a></h1>
 <div class="avoidbreak">
   <address class="vcard">
 	<span class="vcardline">

--- a/draft-ietf-ace-oauth-authz.txt
+++ b/draft-ietf-ace-oauth-authz.txt
@@ -5,14 +5,14 @@
 ACE Working Group                                               L. Seitz
 Internet-Draft                                                 RISE SICS
 Intended status: Standards Track                             G. Selander
-Expires: May 27, 2018                                           Ericsson
+Expires: June 21, 2018                                          Ericsson
                                                            E. Wahlstroem
 
                                                               S. Erdtman
                                                               Spotify AB
                                                            H. Tschofenig
                                                                 ARM Ltd.
-                                                       November 23, 2017
+                                                       December 18, 2017
 
 
   Authentication and Authorization for Constrained Environments (ACE)
@@ -43,7 +43,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on May 27, 2018.
+   This Internet-Draft will expire on June 21, 2018.
 
 Copyright Notice
 
@@ -53,9 +53,9 @@ Copyright Notice
 
 
 
-Seitz, et al.             Expires May 27, 2018                  [Page 1]
+Seitz, et al.             Expires June 21, 2018                 [Page 1]
 
-Internet-Draft                     ACE                     November 2017
+Internet-Draft                     ACE                     December 2017
 
 
    This document is subject to BCP 78 and the IETF Trust's Legal
@@ -94,7 +94,7 @@ Table of Contents
          5.6.4.3.  Token Type  . . . . . . . . . . . . . . . . . . .  26
          5.6.4.4.  Profile . . . . . . . . . . . . . . . . . . . . .  26
          5.6.4.5.  Confirmation  . . . . . . . . . . . . . . . . . .  26
-       5.6.5.  Mapping parameters to CBOR  . . . . . . . . . . . . .  27
+       5.6.5.  Mapping Parameters to CBOR  . . . . . . . . . . . . .  27
      5.7.  The 'Introspect' Endpoint . . . . . . . . . . . . . . . .  28
        5.7.1.  RS-to-AS Request  . . . . . . . . . . . . . . . . . .  29
        5.7.2.  AS-to-RS Response . . . . . . . . . . . . . . . . . .  29
@@ -109,9 +109,9 @@ Table of Contents
 
 
 
-Seitz, et al.             Expires May 27, 2018                  [Page 2]
+Seitz, et al.             Expires June 21, 2018                 [Page 2]
 
-Internet-Draft                     ACE                     November 2017
+Internet-Draft                     ACE                     December 2017
 
 
      6.2.  Use of Nonces for Replay Protection . . . . . . . . . . .  37
@@ -165,9 +165,9 @@ Internet-Draft                     ACE                     November 2017
 
 
 
-Seitz, et al.             Expires May 27, 2018                  [Page 3]
+Seitz, et al.             Expires June 21, 2018                 [Page 3]
 
-Internet-Draft                     ACE                     November 2017
+Internet-Draft                     ACE                     December 2017
 
 
    resource hosted on a device, the resource server (RS).  This exchange
@@ -221,9 +221,9 @@ Internet-Draft                     ACE                     November 2017
 
 
 
-Seitz, et al.             Expires May 27, 2018                  [Page 4]
+Seitz, et al.             Expires June 21, 2018                 [Page 4]
 
-Internet-Draft                     ACE                     November 2017
+Internet-Draft                     ACE                     December 2017
 
 
    Certain security-related terms such as "authentication",
@@ -248,7 +248,7 @@ Internet-Draft                     ACE                     November 2017
    resources, the actors has been simplified by assuming that the client
    authorization server (CAS) functionality is not stand-alone but
    subsumed by either the authorization server or the client (see
-   section 2.2 in [I-D.ietf-ace-actors]).
+   Section 2.2 in [I-D.ietf-ace-actors]).
 
    The specifications in this document is called the "framework" or "ACE
    framework".  When referring to "profiles of this framework" it refers
@@ -277,9 +277,9 @@ Internet-Draft                     ACE                     November 2017
 
 
 
-Seitz, et al.             Expires May 27, 2018                  [Page 5]
+Seitz, et al.             Expires June 21, 2018                 [Page 5]
 
-Internet-Draft                     ACE                     November 2017
+Internet-Draft                     ACE                     December 2017
 
 
    reduces overhead and message exchanges.  While this specification
@@ -333,9 +333,9 @@ Internet-Draft                     ACE                     November 2017
 
 
 
-Seitz, et al.             Expires May 27, 2018                  [Page 6]
+Seitz, et al.             Expires June 21, 2018                 [Page 6]
 
-Internet-Draft                     ACE                     November 2017
+Internet-Draft                     ACE                     December 2017
 
 
    The token and introspection Endpoints:
@@ -389,9 +389,9 @@ Internet-Draft                     ACE                     November 2017
 
 
 
-Seitz, et al.             Expires May 27, 2018                  [Page 7]
+Seitz, et al.             Expires June 21, 2018                 [Page 7]
 
-Internet-Draft                     ACE                     November 2017
+Internet-Draft                     ACE                     December 2017
 
 
       Symmetric PoP key:
@@ -445,9 +445,9 @@ Internet-Draft                     ACE                     November 2017
 
 
 
-Seitz, et al.             Expires May 27, 2018                  [Page 8]
+Seitz, et al.             Expires June 21, 2018                 [Page 8]
 
-Internet-Draft                     ACE                     November 2017
+Internet-Draft                     ACE                     December 2017
 
 
       audience of an access token can be a specific resource or one or
@@ -501,9 +501,9 @@ Internet-Draft                     ACE                     November 2017
 
 
 
-Seitz, et al.             Expires May 27, 2018                  [Page 9]
+Seitz, et al.             Expires June 21, 2018                 [Page 9]
 
-Internet-Draft                     ACE                     November 2017
+Internet-Draft                     ACE                     December 2017
 
 
    protection, and a secure binding between CoAP request and response
@@ -557,9 +557,9 @@ Internet-Draft                     ACE                     November 2017
 
 
 
-Seitz, et al.             Expires May 27, 2018                 [Page 10]
+Seitz, et al.             Expires June 21, 2018                [Page 10]
 
-Internet-Draft                     ACE                     November 2017
+Internet-Draft                     ACE                     December 2017
 
 
    or onboarded) to an AS using a mechanism defined outside the scope of
@@ -613,9 +613,9 @@ Internet-Draft                     ACE                     November 2017
 
 
 
-Seitz, et al.             Expires May 27, 2018                 [Page 11]
+Seitz, et al.             Expires June 21, 2018                [Page 11]
 
-Internet-Draft                     ACE                     November 2017
+Internet-Draft                     ACE                     December 2017
 
 
    +--------+                               +---------------+
@@ -669,9 +669,9 @@ Internet-Draft                     ACE                     November 2017
 
 
 
-Seitz, et al.             Expires May 27, 2018                 [Page 12]
+Seitz, et al.             Expires June 21, 2018                [Page 12]
 
-Internet-Draft                     ACE                     November 2017
+Internet-Draft                     ACE                     December 2017
 
 
       Depending on the device limitations and the selected protocol,
@@ -725,9 +725,9 @@ Internet-Draft                     ACE                     November 2017
 
 
 
-Seitz, et al.             Expires May 27, 2018                 [Page 13]
+Seitz, et al.             Expires June 21, 2018                [Page 13]
 
-Internet-Draft                     ACE                     November 2017
+Internet-Draft                     ACE                     December 2017
 
 
       The RS uses the dynamically established keys to protect the
@@ -781,9 +781,9 @@ Internet-Draft                     ACE                     November 2017
 
 
 
-Seitz, et al.             Expires May 27, 2018                 [Page 14]
+Seitz, et al.             Expires June 21, 2018                [Page 14]
 
-Internet-Draft                     ACE                     November 2017
+Internet-Draft                     ACE                     December 2017
 
 
    Profiles MUST specify how mutual authentication is done, depending
@@ -837,9 +837,9 @@ Internet-Draft                     ACE                     November 2017
 
 
 
-Seitz, et al.             Expires May 27, 2018                 [Page 15]
+Seitz, et al.             Expires June 21, 2018                [Page 15]
 
-Internet-Draft                     ACE                     November 2017
+Internet-Draft                     ACE                     December 2017
 
 
    Unauthorized Resource Request messages MUST be denied with a client
@@ -893,9 +893,9 @@ Internet-Draft                     ACE                     November 2017
 
 
 
-Seitz, et al.             Expires May 27, 2018                 [Page 16]
+Seitz, et al.             Expires June 21, 2018                [Page 16]
 
-Internet-Draft                     ACE                     November 2017
+Internet-Draft                     ACE                     December 2017
 
 
        4.01 Unauthorized
@@ -949,9 +949,9 @@ Internet-Draft                     ACE                     November 2017
 
 
 
-Seitz, et al.             Expires May 27, 2018                 [Page 17]
+Seitz, et al.             Expires June 21, 2018                [Page 17]
 
-Internet-Draft                     ACE                     November 2017
+Internet-Draft                     ACE                     December 2017
 
 
    grant is recommended.  If the client acts on behalf of the resource
@@ -1005,9 +1005,9 @@ Internet-Draft                     ACE                     November 2017
 
 
 
-Seitz, et al.             Expires May 27, 2018                 [Page 18]
+Seitz, et al.             Expires June 21, 2018                [Page 18]
 
-Internet-Draft                     ACE                     November 2017
+Internet-Draft                     ACE                     December 2017
 
 
    If clients involved cannot support HTTP and TLS, profiles MAY define
@@ -1022,6 +1022,15 @@ Internet-Draft                     ACE                     November 2017
    public keys.  Furthermore, this framework defines encodings using
    CBOR, as a substitute for JSON.
 
+   The endpoint may, however, be exposed over HTTPS as in classical
+   OAuth or even other transports.  A profile MUST define the details of
+   the mapping between the fields described below, and these transports.
+   If HTTPS is used, JSON or CBOR payloads may be supported.  If JSON
+   payloads are used, the semantics of Section 4 of the OAuth 2.0
+   specification MUST be followed (with additions as described below).
+   If CBOR payload is supported, the semantics described below MUST be
+   followed.
+
    For the AS to be able to issue a token, the client MUST be
    authenticated and present a valid grant for the scopes requested.
    Profiles of this framework MUST specify how the AS authenticates the
@@ -1034,20 +1043,28 @@ Internet-Draft                     ACE                     November 2017
    The figures of this section use CBOR diagnostic notation without the
    integer abbreviations for the parameters or their values for
    illustrative purposes.  Note that implementations MUST use the
-   integer abbreviations and the binary CBOR encoding.
+   integer abbreviations and the binary CBOR encoding, if the CBOR
+   encoding is used.
 
 5.6.1.  Client-to-AS Request
 
    The client sends a POST request to the token endpoint at the AS.  The
    profile MUST specify the Content-Type and wrapping of the payload.
    The content of the request consists of the parameters specified in
-   section 4 of the OAuth 2.0 specification [RFC6749], encoded as a CBOR
-   map, where the "scope" parameter can additionally be formatted as a
-   byte array, in order to allow compact encoding of complex scope
-   structures.
+   Section 4 of the OAuth 2.0 specification [RFC6749], encoded as a CBOR
+   map (if a CBOR encoding is used), where the "scope" parameter can
+   additionally be formatted as a byte array, in order to allow compact
+   encoding of complex scope structures.
 
    In addition to these parameters, this framework defines the following
    parameters for requesting an access token from a token endpoint:
+
+
+
+Seitz, et al.             Expires June 21, 2018                [Page 19]
+
+Internet-Draft                     ACE                     December 2017
+
 
    aud
       OPTIONAL.  Specifies the audience for which the client is
@@ -1057,15 +1074,6 @@ Internet-Draft                     ACE                     November 2017
       If a client submits a request for an access token without
       specifying an "aud" parameter, and the AS does not have an
       implicit understanding of the "aud" value for this client, then
-
-
-
-
-Seitz, et al.             Expires May 27, 2018                 [Page 19]
-
-Internet-Draft                     ACE                     November 2017
-
-
       the AS MUST respond with an error message using a response code
       equivalent to the CoAP response code 4.00 (Bad Request).
 
@@ -1083,9 +1091,10 @@ Internet-Draft                     ACE                     November 2017
 
    Figure 5 shows a request for a token with a symmetric proof-of-
    possession key.  Note that in this example it is assumed that
-   transport layer communication security is used, therefore the
-   Content-Type is "application/cbor".  The content is displayed in CBOR
-   diagnostic notation, without abbreviations for better readability.
+   transport layer communication security is used with a CBOR payload,
+   therefore the Content-Type is "application/cbor".  The content is
+   displayed in CBOR diagnostic notation, without abbreviations for
+   better readability.
 
    Header: POST (Code=0.02)
    Uri-Host: "as.example.com"
@@ -1108,18 +1117,9 @@ Internet-Draft                     ACE                     November 2017
 
 
 
-
-
-
-
-
-
-
-
-
-Seitz, et al.             Expires May 27, 2018                 [Page 20]
+Seitz, et al.             Expires June 21, 2018                [Page 20]
 
-Internet-Draft                     ACE                     November 2017
+Internet-Draft                     ACE                     December 2017
 
 
    Header: POST (Code=0.02)
@@ -1154,11 +1154,11 @@ Internet-Draft                     ACE                     November 2017
 
    Figure 7 shows a request for a token where a previously communicated
    proof-of-possession key is only referenced.  Note that a transport
-   layer based communication security profile is assumed in this
-   example, therefore the Content-Type is "application/cbor".  Also note
-   that the client performs a password based authentication in this
-   example by submitting its client_secret (see section 2.3.1. of
-   [RFC6749]).
+   layer based communication security profile with a CBOR payload is
+   assumed in this example, therefore the Content-Type is "application/
+   cbor".  Also note that the client performs a password based
+   authentication in this example by submitting its client_secret (see
+   Section 2.3.1 of [RFC6749]).
 
 
 
@@ -1173,9 +1173,9 @@ Internet-Draft                     ACE                     November 2017
 
 
 
-Seitz, et al.             Expires May 27, 2018                 [Page 21]
+Seitz, et al.             Expires June 21, 2018                [Page 21]
 
-Internet-Draft                     ACE                     November 2017
+Internet-Draft                     ACE                     December 2017
 
 
    Header: POST (Code=0.02)
@@ -1212,10 +1212,11 @@ Internet-Draft                     ACE                     November 2017
    Appendix D.  This prior knowledge may, for example, be set by the use
    of a dynamic client registration protocol exchange [RFC7591].
 
-   The content of the successful reply is the RS Information.  It MUST
-   be encoded as CBOR map, containing parameters as specified in section
-   5.1 of [RFC6749].  In addition to these parameters, the following
-   parameters are also part of a successful response:
+   The content of the successful reply is the RS Information.  When
+   using CBOR payloads, the content MUST be encoded as CBOR map,
+   containing parameters as specified in Section 5.1 of [RFC6749].  In
+   addition to these parameters, the following parameters are also part
+   of a successful response:
 
    profile  OPTIONAL.  This indicates the profile that the client MUST
       use towards the RS.  See Section 5.6.4.4 for the formatting of
@@ -1228,10 +1229,9 @@ Internet-Draft                     ACE                     November 2017
 
 
 
-
-Seitz, et al.             Expires May 27, 2018                 [Page 22]
+Seitz, et al.             Expires June 21, 2018                [Page 22]
 
-Internet-Draft                     ACE                     November 2017
+Internet-Draft                     ACE                     December 2017
 
 
       proof-of-possession key the client is supposed to use.  See
@@ -1279,15 +1279,15 @@ Internet-Draft                     ACE                     November 2017
 
    Figure 9 shows a response containing a token and a "cnf" parameter
    with a symmetric proof-of-possession key.  Note that transport layer
-   security is assumed in this example, therefore the Content-Type is
-   "application/cbor".
+   security with CBOR encoding is assumed in this example, therefore the
+   Content-Type is "application/cbor".
 
 
 
 
-Seitz, et al.             Expires May 27, 2018                 [Page 23]
+Seitz, et al.             Expires June 21, 2018                [Page 23]
 
-Internet-Draft                     ACE                     November 2017
+Internet-Draft                     ACE                     December 2017
 
 
    Header: Created (Code=2.01)
@@ -1315,7 +1315,7 @@ Internet-Draft                     ACE                     November 2017
 
    The error responses for CoAP-based interactions with the AS are
    equivalent to the ones for HTTP-based interactions as defined in
-   section 5.2 of [RFC6749], with the following differences:
+   Section 5.2 of [RFC6749], with the following differences:
 
    o  The Content-Type MUST be specified by the communication security
       profile used between client and AS.  The raw payload before being
@@ -1325,11 +1325,13 @@ Internet-Draft                     ACE                     November 2017
       MUST be used for all error responses, except for invalid_client
       where a response code equivalent to the CoAP code 4.01
       (Unauthorized) MAY be used under the same conditions as specified
-      in section 5.2 of [RFC6749].
+      in Section 5.2 of [RFC6749].
    o  The parameters "error", "error_description" and "error_uri" MUST
-      be abbreviated using the codes specified in Figure 12.
+      be abbreviated using the codes specified in Figure 12, when a CBOR
+      encoding is used.
    o  The error code (i.e., value of the "error" parameter) MUST be
-      abbreviated as specified in Figure 10.
+      abbreviated as specified in Figure 10, when a CBOR encoding is
+      used.
 
 
 
@@ -1339,11 +1341,9 @@ Internet-Draft                     ACE                     November 2017
 
 
 
-
-
-Seitz, et al.             Expires May 27, 2018                 [Page 24]
+Seitz, et al.             Expires June 21, 2018                [Page 24]
 
-Internet-Draft                     ACE                     November 2017
+Internet-Draft                     ACE                     December 2017
 
 
            /------------------------+----------\
@@ -1377,13 +1377,14 @@ Internet-Draft                     ACE                     November 2017
 5.6.4.1.  Audience
 
    This parameter specifies for which audience the client is requesting
-   a token.  It should be encoded as CBOR text string.  The formatting
-   and semantics of these strings are application specific.
+   a token.  If using CBOR payload it should be encoded as CBOR text
+   string.  The formatting and semantics of these strings are
+   application specific.
 
 5.6.4.2.  Grant Type
 
    The abbreviations in Figure 11 MUST be used in CBOR encodings instead
-   of the string values defined in [RFC6749].
+   of the string values defined in [RFC6749], if CBOR payloads are used.
 
 
 
@@ -1396,10 +1397,9 @@ Internet-Draft                     ACE                     November 2017
 
 
 
-
-Seitz, et al.             Expires May 27, 2018                 [Page 25]
+Seitz, et al.             Expires June 21, 2018                [Page 25]
 
-Internet-Draft                     ACE                     November 2017
+Internet-Draft                     ACE                     December 2017
 
 
            /--------------------+----------+------------------------\
@@ -1424,7 +1424,8 @@ Internet-Draft                     ACE                     November 2017
    the proof-of-possession is performed MUST be specified by the
    profiles.
 
-   The values in the "token_type" parameter MUST be CBOR text strings.
+   The values in the "token_type" parameter MUST be CBOR text strings,
+   if a CBOR encoding is used.
 
    In this framework token type "pop" MUST be assumed by default if the
    AS does not provide a different value.
@@ -1448,15 +1449,17 @@ Internet-Draft                     ACE                     November 2017
 
    The "cnf" parameter identifies or provides the key used for proof-of-
    possession, while the "rs_cnf" parameter provides the raw public key
+
+
+
+
+Seitz, et al.             Expires June 21, 2018                [Page 26]
+
+Internet-Draft                     ACE                     December 2017
+
+
    of the RS.  Both parameters use the same formatting and semantics as
    the "cnf" claim specified in [I-D.ietf-ace-cwt-proof-of-possession].
-
-
-
-Seitz, et al.             Expires May 27, 2018                 [Page 26]
-
-Internet-Draft                     ACE                     November 2017
-
 
    In addition to the use as a claim in a CWT, the "cnf" parameter is
    used in the following contexts with the following meaning:
@@ -1478,11 +1481,11 @@ Internet-Draft                     ACE                     November 2017
    parameters.  An RS MUST reject a proof-of-possession using such a
    key.
 
-5.6.5.  Mapping parameters to CBOR
+5.6.5.  Mapping Parameters to CBOR
 
    All OAuth parameters in access token requests and responses MUST be
    mapped to CBOR types as specified in Figure 12, using the given
-   integer abbreviation for the key.
+   integer abbreviation for the key, if a CBOR encoding is used.
 
    Note that we have aligned these abbreviations with the claim
    abbreviations defined in [I-D.ietf-ace-cbor-web-token].
@@ -1506,12 +1509,9 @@ Internet-Draft                     ACE                     November 2017
 
 
 
-
-
-
-Seitz, et al.             Expires May 27, 2018                 [Page 27]
+Seitz, et al.             Expires June 21, 2018                [Page 27]
 
-Internet-Draft                     ACE                     November 2017
+Internet-Draft                     ACE                     December 2017
 
 
            /-------------------+----------+---------------------\
@@ -1565,9 +1565,9 @@ Internet-Draft                     ACE                     November 2017
 
 
 
-Seitz, et al.             Expires May 27, 2018                 [Page 28]
+Seitz, et al.             Expires June 21, 2018                [Page 28]
 
-Internet-Draft                     ACE                     November 2017
+Internet-Draft                     ACE                     December 2017
 
 
    The default name of this endpoint in an url-path is 'introspect',
@@ -1591,7 +1591,7 @@ Internet-Draft                     ACE                     November 2017
    additional context that is known by the RS to aid the AS in its
    response MAY be included.
 
-   The same parameters are required and optional as in section 2.1 of
+   The same parameters are required and optional as in Section 2.1 of
    RFC 7662 [RFC7662].
 
    For example, Figure 13 shows a RS calling the token introspection
@@ -1621,14 +1621,14 @@ Internet-Draft                     ACE                     November 2017
 
 
 
-Seitz, et al.             Expires May 27, 2018                 [Page 29]
+Seitz, et al.             Expires June 21, 2018                [Page 29]
 
-Internet-Draft                     ACE                     November 2017
+Internet-Draft                     ACE                     December 2017
 
 
    In a successful response, the AS encodes the response parameters in a
    CBOR map including with the same required and optional parameters as
-   in section 2.2. of RFC 7662 [RFC7662] with the following additions:
+   in Section 2.2. of RFC 7662 [RFC7662] with the following additions:
 
    cnf  OPTIONAL.  This field contains information about the proof-of-
       possession key that binds the client to the access token.  See
@@ -1669,7 +1669,7 @@ Internet-Draft                     ACE                     November 2017
 
    The error responses for CoAP-based interactions with the AS are
    equivalent to the ones for HTTP-based interactions as defined in
-   section 2.3 of [RFC7662], with the following differences:
+   Section 2.3 of [RFC7662], with the following differences:
 
    o  If content is sent, the Content-Type MUST be set according to the
       specification of the communication security profile, and the
@@ -1677,15 +1677,15 @@ Internet-Draft                     ACE                     November 2017
 
 
 
-Seitz, et al.             Expires May 27, 2018                 [Page 30]
+Seitz, et al.             Expires June 21, 2018                [Page 30]
 
-Internet-Draft                     ACE                     November 2017
+Internet-Draft                     ACE                     December 2017
 
 
    o  If the credentials used by the RS are invalid the AS MUST respond
       with the response code equivalent to the CoAP code 4.01
       (Unauthorized) and use the required and optional parameters from
-      section 5.2 in RFC 6749 [RFC6749].
+      Section 5.2 in RFC 6749 [RFC6749].
    o  If the RS does not have the right to perform this introspection
       request, the AS MUST respond with a response code equivalent to
       the CoAP code 4.03 (Forbidden).  In this case no payload is
@@ -1733,9 +1733,9 @@ Internet-Draft                     ACE                     November 2017
 
 
 
-Seitz, et al.             Expires May 27, 2018                 [Page 31]
+Seitz, et al.             Expires June 21, 2018                [Page 31]
 
-Internet-Draft                     ACE                     November 2017
+Internet-Draft                     ACE                     December 2017
 
 
                      Resource       Authorization
@@ -1789,9 +1789,9 @@ Internet-Draft                     ACE                     November 2017
 
 
 
-Seitz, et al.             Expires May 27, 2018                 [Page 32]
+Seitz, et al.             Expires June 21, 2018                [Page 32]
 
-Internet-Draft                     ACE                     November 2017
+Internet-Draft                     ACE                     December 2017
 
 
 5.7.5.  Mapping Introspection parameters to CBOR
@@ -1840,14 +1840,14 @@ Internet-Draft                     ACE                     November 2017
 
    The "scope" claim explicitly encodes the scope of a given access
    token.  This claim follows the same encoding rules as defined in
-   section 3.3 of [RFC6749], but in addition implementers MAY use byte
+   Section 3.3 of [RFC6749], but in addition implementers MAY use byte
    arrays as scope values, to achieve compact encoding of large scope
 
 
 
-Seitz, et al.             Expires May 27, 2018                 [Page 33]
+Seitz, et al.             Expires June 21, 2018                [Page 33]
 
-Internet-Draft                     ACE                     November 2017
+Internet-Draft                     ACE                     December 2017
 
 
    elements.  The meaning of a specific scope value is application
@@ -1901,9 +1901,9 @@ Internet-Draft                     ACE                     November 2017
 
 
 
-Seitz, et al.             Expires May 27, 2018                 [Page 34]
+Seitz, et al.             Expires June 21, 2018                [Page 34]
 
-Internet-Draft                     ACE                     November 2017
+Internet-Draft                     ACE                     December 2017
 
 
    The default name of this endpoint in an url-path is 'authz-info',
@@ -1957,9 +1957,9 @@ Internet-Draft                     ACE                     November 2017
 
 
 
-Seitz, et al.             Expires May 27, 2018                 [Page 35]
+Seitz, et al.             Expires June 21, 2018                [Page 35]
 
-Internet-Draft                     ACE                     November 2017
+Internet-Draft                     ACE                     December 2017
 
 
    A large range of threats can be mitigated by protecting the contents
@@ -1989,7 +1989,7 @@ Internet-Draft                     ACE                     November 2017
    to an eavesdropper thereby completely negating proof-of-possession
    security.  Profiles MUST specify how confidentiality protection is
    provided, and additional protection can be applied by encrypting the
-   token, for example encryption of CWTs is specified in section 5.1 of
+   token, for example encryption of CWTs is specified in Section 5.1 of
    [I-D.ietf-ace-cbor-web-token].
 
    Developers MUST ensure that the ephemeral credentials (i.e., the
@@ -2013,9 +2013,9 @@ Internet-Draft                     ACE                     November 2017
 
 
 
-Seitz, et al.             Expires May 27, 2018                 [Page 36]
+Seitz, et al.             Expires June 21, 2018                [Page 36]
 
-Internet-Draft                     ACE                     November 2017
+Internet-Draft                     ACE                     December 2017
 
 
    possession SHOULD NOT be targeted at an audience that contains more
@@ -2069,9 +2069,9 @@ Internet-Draft                     ACE                     November 2017
 
 
 
-Seitz, et al.             Expires May 27, 2018                 [Page 37]
+Seitz, et al.             Expires June 21, 2018                [Page 37]
 
-Internet-Draft                     ACE                     November 2017
+Internet-Draft                     ACE                     December 2017
 
 
 7.  Privacy Considerations
@@ -2125,9 +2125,9 @@ Internet-Draft                     ACE                     November 2017
 
 
 
-Seitz, et al.             Expires May 27, 2018                 [Page 38]
+Seitz, et al.             Expires June 21, 2018                [Page 38]
 
-Internet-Draft                     ACE                     November 2017
+Internet-Draft                     ACE                     December 2017
 
 
    The columns of this table are:
@@ -2155,7 +2155,7 @@ Internet-Draft                     ACE                     November 2017
 
    The columns of this table are:
 
-   Name  The OAuth Error Code name, refers to the name in section 5.2.
+   Name  The OAuth Error Code name, refers to the name in Section 5.2.
       of [RFC6749] e.g., "invalid_request".
    CBOR Key  The unsigned integer value abbreviating this error code.
       Registration in the table is based on the value of the mapping
@@ -2181,9 +2181,9 @@ Internet-Draft                     ACE                     November 2017
 
 
 
-Seitz, et al.             Expires May 27, 2018                 [Page 39]
+Seitz, et al.             Expires June 21, 2018                [Page 39]
 
-Internet-Draft                     ACE                     November 2017
+Internet-Draft                     ACE                     December 2017
 
 
    Name  The name of the grant type as specified in Section 1.3 of
@@ -2237,9 +2237,9 @@ Internet-Draft                     ACE                     November 2017
 
 
 
-Seitz, et al.             Expires May 27, 2018                 [Page 40]
+Seitz, et al.             Expires June 21, 2018                [Page 40]
 
-Internet-Draft                     ACE                     November 2017
+Internet-Draft                     ACE                     December 2017
 
 
 8.5.1.  Initial Registry Contents
@@ -2293,9 +2293,9 @@ Internet-Draft                     ACE                     November 2017
 
 
 
-Seitz, et al.             Expires May 27, 2018                 [Page 41]
+Seitz, et al.             Expires June 21, 2018                [Page 41]
 
-Internet-Draft                     ACE                     November 2017
+Internet-Draft                     ACE                     December 2017
 
 
    o  Parameter Usage Location: token response
@@ -2349,9 +2349,9 @@ Internet-Draft                     ACE                     November 2017
 
 
 
-Seitz, et al.             Expires May 27, 2018                 [Page 42]
+Seitz, et al.             Expires June 21, 2018                [Page 42]
 
-Internet-Draft                     ACE                     November 2017
+Internet-Draft                     ACE                     December 2017
 
 
    o  Name: "client_token"
@@ -2405,9 +2405,9 @@ Internet-Draft                     ACE                     November 2017
 
 
 
-Seitz, et al.             Expires May 27, 2018                 [Page 43]
+Seitz, et al.             Expires June 21, 2018                [Page 43]
 
-Internet-Draft                     ACE                     November 2017
+Internet-Draft                     ACE                     December 2017
 
 
    o  Claim Description: The scope of an access token as defined in
@@ -2461,17 +2461,17 @@ Internet-Draft                     ACE                     November 2017
 
 
 
-Seitz, et al.             Expires May 27, 2018                 [Page 44]
+Seitz, et al.             Expires June 21, 2018                [Page 44]
 
-Internet-Draft                     ACE                     November 2017
+Internet-Draft                     ACE                     December 2017
 
 
 10.1.  Normative References
 
    [I-D.ietf-ace-cbor-web-token]
               Jones, M., Wahlstroem, E., Erdtman, S., and H. Tschofenig,
-              "CBOR Web Token (CWT)", draft-ietf-ace-cbor-web-token-09
-              (work in progress), October 2017.
+              "CBOR Web Token (CWT)", draft-ietf-ace-cbor-web-token-10
+              (work in progress), December 2017.
 
    [I-D.ietf-ace-cwt-proof-of-possession]
               Jones, M., Seitz, L., Selander, G., Wahlstroem, E.,
@@ -2517,9 +2517,9 @@ Internet-Draft                     ACE                     November 2017
 
 
 
-Seitz, et al.             Expires May 27, 2018                 [Page 45]
+Seitz, et al.             Expires June 21, 2018                [Page 45]
 
-Internet-Draft                     ACE                     November 2017
+Internet-Draft                     ACE                     December 2017
 
 
    [I-D.ietf-ace-actors]
@@ -2531,8 +2531,8 @@ Internet-Draft                     ACE                     November 2017
    [I-D.ietf-core-object-security]
               Selander, G., Mattsson, J., Palombini, F., and L. Seitz,
               "Object Security for Constrained RESTful Environments
-              (OSCORE)", draft-ietf-core-object-security-06 (work in
-              progress), October 2017.
+              (OSCORE)", draft-ietf-core-object-security-07 (work in
+              progress), November 2017.
 
    [I-D.ietf-core-resource-directory]
               Shelby, Z., Koster, M., Bormann, C., Stok, P., and C.
@@ -2548,7 +2548,7 @@ Internet-Draft                     ACE                     November 2017
    [I-D.ietf-oauth-discovery]
               Jones, M., Sakimura, N., and J. Bradley, "OAuth 2.0
               Authorization Server Metadata", draft-ietf-oauth-
-              discovery-07 (work in progress), September 2017.
+              discovery-08 (work in progress), November 2017.
 
    [I-D.ietf-oauth-native-apps]
               Denniss, W. and J. Bradley, "OAuth 2.0 for Native Apps",
@@ -2573,9 +2573,9 @@ Internet-Draft                     ACE                     November 2017
 
 
 
-Seitz, et al.             Expires May 27, 2018                 [Page 46]
+Seitz, et al.             Expires June 21, 2018                [Page 46]
 
-Internet-Draft                     ACE                     November 2017
+Internet-Draft                     ACE                     December 2017
 
 
    [RFC5246]  Dierks, T. and E. Rescorla, "The Transport Layer Security
@@ -2629,9 +2629,9 @@ Internet-Draft                     ACE                     November 2017
 
 
 
-Seitz, et al.             Expires May 27, 2018                 [Page 47]
+Seitz, et al.             Expires June 21, 2018                [Page 47]
 
-Internet-Draft                     ACE                     November 2017
+Internet-Draft                     ACE                     December 2017
 
 
    [RFC7591]  Richer, J., Ed., Jones, M., Bradley, J., Machulak, M., and
@@ -2685,9 +2685,9 @@ Appendix A.  Design Justification
 
 
 
-Seitz, et al.             Expires May 27, 2018                 [Page 48]
+Seitz, et al.             Expires June 21, 2018                [Page 48]
 
-Internet-Draft                     ACE                     November 2017
+Internet-Draft                     ACE                     December 2017
 
 
    Low CPU Speed:
@@ -2741,9 +2741,9 @@ Internet-Draft                     ACE                     November 2017
 
 
 
-Seitz, et al.             Expires May 27, 2018                 [Page 49]
+Seitz, et al.             Expires June 21, 2018                [Page 49]
 
-Internet-Draft                     ACE                     November 2017
+Internet-Draft                     ACE                     December 2017
 
 
       of different protocols, and not all parts of the message flow are
@@ -2797,9 +2797,9 @@ Internet-Draft                     ACE                     November 2017
 
 
 
-Seitz, et al.             Expires May 27, 2018                 [Page 50]
+Seitz, et al.             Expires June 21, 2018                [Page 50]
 
-Internet-Draft                     ACE                     November 2017
+Internet-Draft                     ACE                     December 2017
 
 
       and stating confirmation keys.  This aims at making token theft
@@ -2853,9 +2853,9 @@ Internet-Draft                     ACE                     November 2017
 
 
 
-Seitz, et al.             Expires May 27, 2018                 [Page 51]
+Seitz, et al.             Expires June 21, 2018                [Page 51]
 
-Internet-Draft                     ACE                     November 2017
+Internet-Draft                     ACE                     December 2017
 
 
       In cases where the client is constrained and does not have
@@ -2909,9 +2909,9 @@ Appendix B.  Roles and Responsibilities
 
 
 
-Seitz, et al.             Expires May 27, 2018                 [Page 52]
+Seitz, et al.             Expires June 21, 2018                [Page 52]
 
-Internet-Draft                     ACE                     November 2017
+Internet-Draft                     ACE                     December 2017
 
 
       *  Optionally: Expose the introspection endpoint that allows RS's
@@ -2965,9 +2965,9 @@ Internet-Draft                     ACE                     November 2017
 
 
 
-Seitz, et al.             Expires May 27, 2018                 [Page 53]
+Seitz, et al.             Expires June 21, 2018                [Page 53]
 
-Internet-Draft                     ACE                     November 2017
+Internet-Draft                     ACE                     December 2017
 
 
          +  Check that the token has not expired (if the token provides
@@ -3021,9 +3021,9 @@ Appendix C.  Requirements on Profiles
 
 
 
-Seitz, et al.             Expires May 27, 2018                 [Page 54]
+Seitz, et al.             Expires June 21, 2018                [Page 54]
 
-Internet-Draft                     ACE                     November 2017
+Internet-Draft                     ACE                     December 2017
 
 
 Appendix D.  Assumptions on AS knowledge about C and RS
@@ -3077,9 +3077,9 @@ E.1.  Local Token Validation
 
 
 
-Seitz, et al.             Expires May 27, 2018                 [Page 55]
+Seitz, et al.             Expires June 21, 2018                [Page 55]
 
-Internet-Draft                     ACE                     November 2017
+Internet-Draft                     ACE                     December 2017
 
 
    This example shows the interactions between a client, the
@@ -3133,9 +3133,9 @@ Internet-Draft                     ACE                     November 2017
 
 
 
-Seitz, et al.             Expires May 27, 2018                 [Page 56]
+Seitz, et al.             Expires June 21, 2018                [Page 56]
 
-Internet-Draft                     ACE                     November 2017
+Internet-Draft                     ACE                     December 2017
 
 
             Authorization
@@ -3189,9 +3189,9 @@ Internet-Draft                     ACE                     November 2017
 
 
 
-Seitz, et al.             Expires May 27, 2018                 [Page 57]
+Seitz, et al.             Expires June 21, 2018                [Page 57]
 
-Internet-Draft                     ACE                     November 2017
+Internet-Draft                     ACE                     December 2017
 
 
    The content of the access token is shown in Figure 19.
@@ -3245,9 +3245,9 @@ Internet-Draft                     ACE                     November 2017
 
 
 
-Seitz, et al.             Expires May 27, 2018                 [Page 58]
+Seitz, et al.             Expires June 21, 2018                [Page 58]
 
-Internet-Draft                     ACE                     November 2017
+Internet-Draft                     ACE                     December 2017
 
 
       The client sends the CoAP request GET to /temperature on RS over
@@ -3301,9 +3301,9 @@ E.2.  Introspection Aided Token Validation
 
 
 
-Seitz, et al.             Expires May 27, 2018                 [Page 59]
+Seitz, et al.             Expires June 21, 2018                [Page 59]
 
-Internet-Draft                     ACE                     November 2017
+Internet-Draft                     ACE                     December 2017
 
 
    resource owner has a connected car, he buys a generic key that he
@@ -3357,9 +3357,9 @@ Internet-Draft                     ACE                     November 2017
 
 
 
-Seitz, et al.             Expires May 27, 2018                 [Page 60]
+Seitz, et al.             Expires June 21, 2018                [Page 60]
 
-Internet-Draft                     ACE                     November 2017
+Internet-Draft                     ACE                     December 2017
 
 
    Request-Payload:
@@ -3413,9 +3413,9 @@ Internet-Draft                     ACE                     November 2017
 
 
 
-Seitz, et al.             Expires May 27, 2018                 [Page 61]
+Seitz, et al.             Expires June 21, 2018                [Page 61]
 
-Internet-Draft                     ACE                     November 2017
+Internet-Draft                     ACE                     December 2017
 
 
               Resource
@@ -3469,9 +3469,9 @@ Internet-Draft                     ACE                     November 2017
 
 
 
-Seitz, et al.             Expires May 27, 2018                 [Page 62]
+Seitz, et al.             Expires June 21, 2018                [Page 62]
 
-Internet-Draft                     ACE                     November 2017
+Internet-Draft                     ACE                     December 2017
 
 
       The client uses the symmetric PoP key to establish a DTLS
@@ -3525,9 +3525,9 @@ F.3.  Version -07 to -08
 
 
 
-Seitz, et al.             Expires May 27, 2018                 [Page 63]
+Seitz, et al.             Expires June 21, 2018                [Page 63]
 
-Internet-Draft                     ACE                     November 2017
+Internet-Draft                     ACE                     December 2017
 
 
    o  Made it mandatory for profiles to specify C-AS security and RS-AS
@@ -3581,9 +3581,9 @@ F.6.  Version -04 to -05
 
 
 
-Seitz, et al.             Expires May 27, 2018                 [Page 64]
+Seitz, et al.             Expires June 21, 2018                [Page 64]
 
-Internet-Draft                     ACE                     November 2017
+Internet-Draft                     ACE                     December 2017
 
 
    o  Added IANA registry mapping the confirmation types from RFC 7800
@@ -3637,9 +3637,9 @@ F.9.  Version -01 to -02
 
 
 
-Seitz, et al.             Expires May 27, 2018                 [Page 65]
+Seitz, et al.             Expires June 21, 2018                [Page 65]
 
-Internet-Draft                     ACE                     November 2017
+Internet-Draft                     ACE                     December 2017
 
 
 F.10.  Version -00 to -01
@@ -3693,9 +3693,9 @@ Authors' Addresses
 
 
 
-Seitz, et al.             Expires May 27, 2018                 [Page 66]
+Seitz, et al.             Expires June 21, 2018                [Page 66]
 
-Internet-Draft                     ACE                     November 2017
+Internet-Draft                     ACE                     December 2017
 
 
    Goeran Selander
@@ -3749,4 +3749,4 @@ Internet-Draft                     ACE                     November 2017
 
 
 
-Seitz, et al.             Expires May 27, 2018                 [Page 67]
+Seitz, et al.             Expires June 21, 2018                [Page 67]

--- a/draft-ietf-ace-oauth-authz.xml
+++ b/draft-ietf-ace-oauth-authz.xml
@@ -282,7 +282,7 @@ participating in the CoAP protocol" is not used in this specification.</t>
 Since this specification focuses on the problem of access control to resources,
 the actors has been simplified by assuming that the client authorization server (CAS)
 functionality is not stand-alone but subsumed by either the authorization
-server or the client (see section 2.2 in <xref target="I-D.ietf-ace-actors"/>).
+server or the client (see Section 2.2 in <xref target="I-D.ietf-ace-actors"/>).
 </t>
 
 <t>The specifications in this document is called the "framework" or "ACE framework".
@@ -977,6 +977,11 @@ a2                                   # map(2)
   establish shared keys or to exchange their public keys.  Furthermore,
   this framework defines encodings using CBOR, as a substitute for JSON.</t>
 
+  <t>The endpoint may, however, be exposed over HTTPS as in classical OAuth or even other transports. 
+  A profile MUST define the details of the mapping between the fields described below, and these transports.
+  If HTTPS is used, JSON or CBOR payloads may be supported. If JSON payloads are used, the semantics of Section 4 of the OAuth 2.0 specification MUST be followed (with additions as described below). If CBOR payload is supported, the semantics described below MUST be followed.</t> 
+
+  
   <t>For the AS to be able to issue a token, the client MUST be authenticated
   and present a valid grant for the scopes requested.  Profiles of this
   framework MUST specify how the AS authenticates the client and how the
@@ -989,14 +994,15 @@ a2                                   # map(2)
   <t>The figures of this section use CBOR diagnostic
   notation without the integer abbreviations for the parameters or their
   values for illustrative purposes. Note that implementations MUST use the
-  integer abbreviations and the binary CBOR encoding.</t>
+  integer abbreviations and the binary CBOR encoding, if the CBOR encoding is used.</t>
 
   <section anchor="tokenRequest" title="Client-to-AS Request">
     <t>The client sends a POST request to the token endpoint
     at the AS. The profile MUST specify the Content-Type and wrapping of the
     payload.  The content of the request consists of the parameters specified
-    in section 4 of the OAuth 2.0 specification <xref
-    target="RFC6749"/>, encoded as a CBOR map, where the "scope" parameter
+    in Section 4 of the OAuth 2.0 specification <xref
+    target="RFC6749"/>, encoded as a CBOR map (if a CBOR encoding is used), 
+	where the "scope" parameter
     can additionally be formatted as a byte array, in order to allow
     compact encoding of complex scope structures.</t>
 
@@ -1032,7 +1038,8 @@ a2                                   # map(2)
 
     <t><xref target="fig:symmATreq"/> shows a request for a token
     with a symmetric proof-of-possession key.  Note that in this example
-    it is assumed that transport layer communication security is used, therefore
+    it is assumed that transport layer communication security is used with a CBOR payload, 
+	therefore
     the Content-Type is "application/cbor".  The content is displayed in
     CBOR diagnostic notation, without abbreviations for better readability.
 
@@ -1094,10 +1101,10 @@ Decrypted payload:
     <t><xref target="fig:kidATreq"/> shows a request for a token
     where a previously communicated proof-of-possession key is only
     referenced.  Note that a transport layer based communication security
-    profile is assumed in this example, therefore the Content-Type is
+    profile with a CBOR payload is assumed in this example, therefore the Content-Type is
     "application/cbor".  Also note that the client performs a password
     based authentication in this example by submitting its client_secret
-    (see section 2.3.1. of <xref target="RFC6749"/>).
+    (see Section 2.3.1 of <xref target="RFC6749"/>).
 
     <figure align="center" anchor="fig:kidATreq"
             title="Example request for an access token bound to a
@@ -1139,8 +1146,9 @@ Payload:
    by the use of a dynamic client registration protocol exchange
    <xref target="RFC7591"/>.</t>
 
-    <t>The content of the successful reply is the RS Information. It MUST be
-    encoded as CBOR map, containing parameters as specified in section 5.1 of
+    <t>The content of the successful reply is the RS Information. 
+	When using CBOR payloads, the content MUST be
+    encoded as CBOR map, containing parameters as specified in Section 5.1 of
     <xref target="RFC6749"/>.  In addition to these parameters, the following
     parameters are also part of a successful response:
 
@@ -1211,7 +1219,7 @@ Payload:
 
     <t><xref target="fig:symmATres"/> shows a response containing a token
     and a "cnf" parameter with a symmetric proof-of-possession key.  Note that
-    transport layer security is assumed in this example,
+    transport layer security with CBOR encoding is assumed in this example,
     therefore the Content-Type is "application/cbor".
 
     <figure align="center" anchor="fig:symmATres"
@@ -1242,7 +1250,7 @@ Payload:
   <section anchor="errorsToken" title="Error Response">
     <t>The error responses for CoAP-based interactions with the AS
     are equivalent to the ones for HTTP-based interactions as defined in
-    section 5.2 of <xref target="RFC6749"/>, with the following differences:
+    Section 5.2 of <xref target="RFC6749"/>, with the following differences:
 
       <list style="symbols">
         <t>The Content-Type MUST be specified by the communication security
@@ -1253,17 +1261,17 @@ Payload:
         <t>A response code equivalent to the CoAP code 4.00 (Bad Request) MUST
 	be used for all error responses, except for invalid_client where a
 	response code equivalent to the CoAP code 4.01 (Unauthorized) MAY be
-	used under the same conditions as specified in section 5.2 of
+	used under the same conditions as specified in Section 5.2 of
 	<xref target="RFC6749"/>.
 	</t>
 
 	<t>The parameters "error", "error_description" and "error_uri" MUST
 	be abbreviated using the codes specified in <xref
-	target="fig:cborTokenParameters"/>.</t>
+	target="fig:cborTokenParameters"/>, when a CBOR encoding is used.</t>
 
 	<t>The error code (i.e., value of the "error" parameter) MUST be
 	abbreviated as specified in <xref
-	target="fig:cborErrorCodes"/>.</t>
+	target="fig:cborErrorCodes"/>, when a CBOR encoding is used.</t>
       </list>
 
       <figure align="center" anchor="fig:cborErrorCodes"
@@ -1301,14 +1309,14 @@ Payload:
 
     <section anchor="paramAud" title="Audience">
       <t>This parameter specifies for which audience the client is requesting
-      a token.  It should be encoded as CBOR text string.  The
+      a token. If using CBOR payload it should be encoded as CBOR text string.  The
       formatting and semantics of these strings are application specific.</t>
     </section>
 
     <section anchor="paramGrantType" title="Grant Type">
       <t>The abbreviations in <xref target="fig:grant_types"/> MUST be
       used in CBOR encodings instead of the string values defined
-      in <xref target="RFC6749"/>.
+      in <xref target="RFC6749"/>, if CBOR payloads are used.
 
       <figure align="center" anchor="fig:grant_types"
               title="CBOR abbreviations for common grant types ">
@@ -1334,7 +1342,7 @@ Payload:
         Token Types registry,  specifying a Proof-of-Possession token.  How the
       proof-of-possession is performed MUST be specified by the profiles.</t>
 
-      <t>The values in the "token_type" parameter MUST be CBOR text strings.</t>
+      <t>The values in the "token_type" parameter MUST be CBOR text strings, if a CBOR encoding is used. </t>
 
       <t>In this framework token type "pop" MUST be assumed by default if the
       AS does not provide a different value.</t>
@@ -1392,11 +1400,11 @@ Payload:
     </section>
   </section> <!--Parameters -->
 
-  <section anchor="tokenCborParams" title="Mapping parameters to CBOR">
+  <section anchor="tokenCborParams" title="Mapping Parameters to CBOR">
     <t>All OAuth parameters in access token requests and responses MUST be
     mapped to CBOR types as specified in <xref
     target="fig:cborTokenParameters"/>, using the given integer abbreviation
-    for the key.</t>
+    for the key, if a CBOR encoding is used.</t>
     <t>Note that we have aligned these abbreviations with the claim
     abbreviations defined in <xref target="I-D.ietf-ace-cbor-web-token"/>.</t>
 
@@ -1472,7 +1480,7 @@ Payload:
     additional context that is known by the RS to aid the AS in its
     response MAY be included.</t>
 
-    <t>The same parameters are required and optional as in section 2.1
+    <t>The same parameters are required and optional as in Section 2.1
     of RFC 7662 <xref target="RFC7662"/>.</t>
 
     <t>For example, <xref target="fig:introReq"/> shows a RS calling the token
@@ -1506,7 +1514,7 @@ Payload:
 
     <t>In a successful response, the AS encodes the response parameters in
     a CBOR map including with the same required and optional parameters as in
-    section 2.2. of RFC 7662 <xref target="RFC7662"/> with the following
+    Section 2.2. of RFC 7662 <xref target="RFC7662"/> with the following
     additions:
 
     <list style="hanging">
@@ -1561,7 +1569,7 @@ Payload:
   <section anchor="errorsIntro" title="Error Response">
     <t>The error responses for CoAP-based interactions with the AS
     are equivalent to the ones for HTTP-based interactions as defined in
-    section 2.3 of <xref target="RFC7662"/>, with the following differences:
+    Section 2.3 of <xref target="RFC7662"/>, with the following differences:
 
     <list style="symbols">
       <t>If content is sent, the Content-Type MUST be set according to the
@@ -1570,7 +1578,7 @@ Payload:
 
       <t>If the credentials used by the RS are invalid the AS MUST respond
       with the response code equivalent to the CoAP code 4.01 (Unauthorized)
-      and use the required and optional parameters from section 5.2 in RFC 6749
+      and use the required and optional parameters from Section 5.2 in RFC 6749
       <xref target="RFC6749"/>.</t>
 
       <t>If the RS does not have the right to perform this introspection
@@ -1724,7 +1732,7 @@ C:  +--------------->|                |
   claim for both JSON and CBOR web tokens.</t>
 
   <t>The "scope" claim explicitly encodes the scope of a given access token.
-  This claim follows the same encoding rules as defined in section 3.3 of <xref
+  This claim follows the same encoding rules as defined in Section 3.3 of <xref
   target="RFC6749"/>, but in addition implementers MAY use byte arrays as scope
   values, to achieve compact encoding of large scope elements.  The meaning of
   a specific scope value is application specific and expected to be known to
@@ -1860,7 +1868,7 @@ C:  +--------------->|                |
       an eavesdropper thereby completely negating proof-of-possession security.
       Profiles MUST specify how confidentiality protection is provided,
       and additional protection can be applied by encrypting the token, for
-      example encryption of CWTs is specified in section 5.1 of
+      example encryption of CWTs is specified in Section 5.1 of
       <xref target="I-D.ietf-ace-cbor-web-token"/>.</t>
 
       <t>Developers MUST ensure that the ephemeral credentials (i.e., the
@@ -2009,7 +2017,7 @@ C:  +--------------->|                |
    
     <list style='hanging'>
       <t hangText='Name'>The OAuth Error Code name, refers to the name in
-      section 5.2. of <xref target="RFC6749"/> e.g., "invalid_request".</t>
+      Section 5.2. of <xref target="RFC6749"/> e.g., "invalid_request".</t>
       
       <t hangText='CBOR Key'> The unsigned integer value abbreviating this
       error code.  Registration in the table is based on the value of the


### PR DESCRIPTION
In off-list discussion the differences between OAuth-ACE, OCF and LwM2M was discussed. One of the distinguishing features of OAuth-ACE is that it allows user authentication and authorization to be conveniently provided. 

However, after re-reading the OAuth-ACE draft I noticed that the use of a smart phone / tablet for accessing IoT devices is actually not well supported due to the decisions made around profiles. 

Hence, this pull request relaxes the OAuth-ACE profiles such that they allow: 
* profiles to specify what protocols and encodings they use between the client and the AS (not just between the client and the RS). 
* support the use of HTTPS and JSON encoding, as described in the original OAuth specification, but with the use of CWTs. 
