### PR TITLE
Define OSCORE keys

### DIFF
--- a/InteropTestPlan.txt
+++ b/InteropTestPlan.txt
@@ -1,18 +1,34 @@
 I. Pre-requisites:
 
-1. Common PSK for 128-bit AES-CCM (in Hex):
+1. Client to AS DTLS keys
+
+1.1. Common PSK for 128-bit AES-CCM (in Hex):
 0x61, 0x62, 0x63, 0x04, 0x05, 0x06, 0x07, 0x08,
 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10
 
 keyId="key128"
 
-2. Common PSK for 256-bit AES-CCM or HMAC-SHA-256
+1.2. Common PSK for 256-bit AES-CCM or HMAC-SHA-256
 0x61, 0x62, 0x63, 0x04, 0x05, 0x06, 0x07, 0x08,
 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10,
 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18,
 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f, 0x20
 
 keyId="key256"
+
+2. OSCORE Keys
+
+These keys are used for the OSCORE profile for communication between the Client and the AS
+or between the Resource Server and the AS.  For communications between the Client and the
+Resource server, a key will be transmitted in the response/token.
+
+2.1 Client to AS OSCORE key
+
+{1:4,2:'os1',6:'clientId',7:'asServerId',-4:h'100f0e0d0c0b0a090a07060504636261'}
+
+2.2 RS to AS OSCORE key
+
+{1:4,2:'os2',6:'rsId',7:'asServerId',-4:h'090a07060504636261100f0e0d0c0b0a'}
 
 3. Common raw asymmetric key pairs (encoded as COSE_Key):
 


### PR DESCRIPTION
We need to have OSCORE keys that can be used for the OSCORE profiles between the Client-AS and RS-AS.