### PR TITLE
Fix CBOR value for P-256 in figure 5

### DIFF
--- a/draft-ietf-ace-oauth-authz.xml
+++ b/draft-ietf-ace-oauth-authz.xml
@@ -1224,9 +1224,9 @@ Decrypted payload:
   / client_id / 24 : "myclient",
   / req_cnf / 4 : {
     / COSE_Key / 1 : {
-      / kty /  1 : 2 /EC2/,
+      / kty /  1 : 2 / EC2 /,
       / kid /  2 : h'11',
-      / crv / -1 : /P-256/,
+      / crv / -1 : 1 / P-256 /,
       / x /   -2 : b64'usWxHK2PmfnHKwXPS54m0kTcGJ90UiglWiGahtagnv8',
       / y /   -3 : b64'IBOL+C3BttVivg+lSreASjpkttcsz+1rb7btKLv8EX4'
     }


### PR DESCRIPTION
The CBOR value for `P-256` is missing in the example in Figure 5.

This patch also introduces whitespace around EC2 and P-256 in Figure 5 for consistency with the other examples.